### PR TITLE
Throw an error when a DefineMap is passed without a "route" property

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -118,6 +118,10 @@ var removeBackslash = function (str) {
 	return str.replace(/\\/g, "");
 };
 
+var isDefineMap = function(map) {
+	return types.isMapLike(map) && typeof map.get === "function";
+};
+
 // A ~~throttled~~ debounced function called multiple times will only fire once the
 // timer runs down. Each call resets the timer.
 var timer;
@@ -853,6 +857,16 @@ Object.defineProperty(canRoute,"data", {
 			setRouteData(data);
 		}
 
+		if(isDefineMap(data) && Object.isSealed(data)) {
+			var proto = data.constructor.prototype;
+			// Set a constructor definition so can-define knows this already exists.
+			var definitions = proto._define.definitions;
+
+			if(!definitions.route) {
+				var errMsg = "Cannot map a DefineMap without a 'route' property defined.";
+				throw new Error(errMsg);
+			}
+		}
 	}
 });
 

--- a/test/mock-route-binding.js
+++ b/test/mock-route-binding.js
@@ -47,6 +47,7 @@ module.exports = {
 	stop: function(){
 		canRoute._teardown();
 		canRoute.defaultBinding = oldDefault;
+		//canRoute.bindings.mock.unbind();
 		//canRoute._setup();
 	},
 	hash: routeCompute

--- a/test/route-define-test.js
+++ b/test/route-define-test.js
@@ -1030,8 +1030,37 @@ test(".url with merge=true (#16)", function(){
 		
 		mockRoute.stop();
 		QUnit.start();
-	},20);
+	},200);
 
+});
+
+test("Throws on DefineMap that's sealed and no 'route' defined", function(){
+	var AppState = DefineMap.extend({
+		page: "string"
+	});
+	var appState = new AppState();
+
+	try {
+		canRoute.map(appState);
+
+		QUnit.ok(false, "This should have thrown");
+	} catch(err) {
+		QUnit.ok(true, "Threw because no 'route' defined");
+	}
+});
+
+test("Throws on a DefineMap derived constructor with no 'route' defined", function(){
+	var AppState = DefineMap.extend({
+		page: "string"
+	});
+	
+	try {
+		canRoute.map(AppState);
+
+		QUnit.ok(false, "This should have thrown");
+	} catch(err) {
+		QUnit.ok(true, "Threw because no 'route' defined");
+	}
 });
 
 }


### PR DESCRIPTION
When a DefineMap is passed to route.map, throw an error if the "route" property is not defined.