### PR TITLE
not showing duplicate route warning when routes have different default values

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -19,6 +19,7 @@ var assign = require("can-util/js/assign/assign");
 var types = require('can-util/js/types/types');
 var dev = require('can-util/js/dev/dev');
 var diff = require('can-util/js/diff/diff');
+var diffObject = require('can-util/js/diff-object/diff-object');
 
 
 // ## route.js
@@ -189,7 +190,10 @@ var canRoute = function (url, defaults) {
 			var existingKeys = r.names.concat(Object.keys(r.defaults)).sort();
 			var keys = names.concat(Object.keys(defaults)).sort();
 
-			if (!diff(existingKeys, keys).length) {
+			var sameMapKeys = !diff(existingKeys, keys).length;
+			var sameDefaultValues = !diffObject(r.defaults, defaults).length;
+
+			if (sameMapKeys && sameDefaultValues) {
 				dev.warn('two routes were registered with matching keys:\n' +
 					'\t(1) route("' + r.route + '", ' + JSON.stringify(r.defaults) + ')\n' +
 					'\t(2) route("' + url + '", ' + JSON.stringify(defaults) + ')\n' +

--- a/test/route-test.js
+++ b/test/route-test.js
@@ -4,6 +4,7 @@ var canRoute = require('can-route');
 var QUnit = require('steal-qunit');
 var Map = require('can-map');
 var makeArray = require('can-util/js/make-array/make-array');
+var dev = require('can-util/js/dev/dev');
 
 require('can-observation');
 
@@ -1070,5 +1071,49 @@ test("matched() compute", function() {
 		start();
 	}, 200);
 });
+
+//!steal-remove-start
+if (dev) {
+	test("should warn when two routes have same map properties", function () {
+		var oldlog = dev.warn;
+
+		dev.warn = function(text) {
+			equal(text.split(":")[0], "two routes were registered with matching keys");
+		};
+
+		canRoute("{page}/{subpage}");
+		canRoute("foo/{page}/{subpage}");
+
+		dev.warn = oldlog;
+	});
+
+	test("should warn when two routes have same map properties - including defaults", function () {
+		var oldlog = dev.warn;
+
+		dev.warn = function(text) {
+			equal(text.split(":")[0], "two routes were registered with matching keys");
+		};
+
+		canRoute("{page}", { subpage: "bar" });
+		canRoute("{page}/{subpage}");
+
+		dev.warn = oldlog;
+	});
+
+	test("should not warn when two routes have same map properties - but different defaults(#36)", function () {
+		expect(0);
+		var oldlog = dev.warn;
+
+		dev.warn = function(text) {
+			ok(false, text);
+		};
+
+		canRoute("login", { "page": "auth", "subpage": "login" });
+		canRoute("signup", { "page": "auth", "subpage": "signup" });
+
+		dev.warn = oldlog;
+	});
+}
+//!steal-remove-end
 
 }


### PR DESCRIPTION
Closes https://github.com/canjs/can-route/issues/36.