### PR TITLE
Allow whitespace in the curly brackets string interpolation

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -30,7 +30,7 @@ var diffObject = require('can-util/js/diff-object/diff-object');
 // Helper methods used for matching routes.
 // `RegExp` used to match route variables of the type '{name}'.
 // Any word character or a period is matched.
-var curliesMatcher = /\{([\w.]+)\}/g;
+var curliesMatcher = /\{\s*([\w.]+)\s*\}/g;
 var colonMatcher = /\:([\w.]+)/g;
 // Regular expression for identifying &amp;key=value lists.
 var paramsMatcher = /^(?:&[^=]+=[^&]*)+/;

--- a/test/route-define-test.js
+++ b/test/route-define-test.js
@@ -1061,3 +1061,35 @@ test("matched() compute", function() {
 });
 
 }
+
+test("param with whitespace in interpolated string (#45)", function () {
+	canRoute.routes = {};
+	canRoute("{ page }", {
+		page: "index"
+	})
+
+	var res = canRoute.param({
+		page: "index"
+	});
+	equal(res, "")
+
+	canRoute("pages/{ p1 }/{    p2   }/{	p3	}", {
+		p1: "index",
+		p2: "foo",
+		p3: "bar"
+	})
+
+	res = canRoute.param({
+		p1: "index",
+		p2: "foo",
+		p3: "bar"
+	});
+	equal(res, "pages///")
+
+	res = canRoute.param({
+		p1: "index",
+		p2: "baz",
+		p3: "bar"
+	});
+	equal(res, "pages//baz/")
+});


### PR DESCRIPTION
fixes #45 

Let's you do stuff like this:

```javascript
canRoute("pages/{ p1 }/{    p2   }/{	p3	}", {
    p1: "index",
    p2: "foo",
    p3: "bar"
})

canRoute.param({p1: "index", p2: "foo", p3: "bar" }); // returns "pages///"
```