### PR TITLE
Fix decoding of unicode sequence

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,7 +21,8 @@
 		"start": true,
 		"stop": true,
 		"global": true,
-		"Promise": true
+		"Promise": true,
+		"unescape": true
 	},
 	"strict": false,
 	"curly": true,

--- a/can-route.js
+++ b/can-route.js
@@ -334,6 +334,14 @@ setState =canRoute.setState = function () {
 	}
 };
 
+var decode = function(str){
+	try {
+		return decodeURIComponent(str);
+	} catch(ex) {
+		return unescape(str);
+	}
+};
+
 /**
  * @static
  */
@@ -528,7 +536,7 @@ assign(canRoute, {
 			// parts if that part is not empty.
 			each(parts, function (part, i) {
 				if (part && part !== querySeparator) {
-					obj[route.names[i]] = decodeURIComponent(part);
+					obj[route.names[i]] = decode(part);
 				}
 			});
 			obj.route = route.route;

--- a/test/route-test.js
+++ b/test/route-test.js
@@ -96,6 +96,13 @@ test("deparam - `:page` syntax", function () {
 		where: "there",
 		route: ":page/:index"
 	}, "default value and queryparams");
+
+	obj = canRoute.deparam("foo/%0g");
+	deepEqual(obj, {
+		index: "%0g",
+		page: "foo",
+		route: ":page/:index"
+	}, "can decode malformed urls");
 });
 
 test("deparam of invalid url", function () {


### PR DESCRIPTION
This fixes the case where you are deparaming a unicode sequence that is
not a valid character. decodeURIComponent will throw in these cases, so
we fall back to unescape.

Closes #76