### PR TITLE
Expose internal canEvent __url events to canRoute

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -873,17 +873,20 @@ assign(canRoute, {
 // The functions in the following list applied to `canRoute` (e.g. `canRoute.attr('...')`) will
 // instead act on the `canRoute.data` observe.
 
+var bindToCanRouteData = function(name, args) {
+	if (!canRoute.data[name]) {
+		return;
+	}
+	return canRoute.data[name].apply(canRoute.data, args);
+};
+
 each(['addEventListener','removeEventListener','bind', 'unbind', 'on', 'off'], function(name) {
 	// exposing all internal canEvent evt's to canRoute
 	canRoute[name] = function(eventName) {
 		if (eventName === '__url') {
 			return canEvent[name].apply(eventsObject, arguments);
 		}
-
-		if (!canRoute.data[name]) {
-			return;
-		}
-		return canRoute.data[name].apply(canRoute.data, arguments);
+		return bindToCanRouteData(name, arguments);
 	};
 });
 
@@ -891,11 +894,7 @@ each(['delegate', 'undelegate', 'removeAttr', 'compute', '_get', '___get', 'each
 	canRoute[name] = function () {
 		// `delegate` and `undelegate` require
 		// the `can/map/delegate` plugin
-		if (!canRoute.data[name]) {
-			return;
-		}
-
-		return canRoute.data[name].apply(canRoute.data, arguments);
+		return bindToCanRouteData(name, arguments);
 	};
 });
 

--- a/can-route.js
+++ b/can-route.js
@@ -875,8 +875,15 @@ assign(canRoute, {
 
 each(['addEventListener','removeEventListener','bind', 'unbind', 'on', 'off'], function(name) {
 	// exposing all internal canEvent evt's to canRoute
-	canRoute[name] = function() {
-		return canEvent[name].apply(eventsObject, arguments);
+	canRoute[name] = function(eventName) {
+		if (eventName === '__url') {
+			return canEvent[name].apply(eventsObject, arguments);
+		}
+
+		if (!canRoute.data[name]) {
+			return;
+		}
+		return canRoute.data[name].apply(canRoute.data, arguments);
 	};
 });
 

--- a/can-route.js
+++ b/can-route.js
@@ -872,7 +872,15 @@ assign(canRoute, {
 
 // The functions in the following list applied to `canRoute` (e.g. `canRoute.attr('...')`) will
 // instead act on the `canRoute.data` observe.
-each(['addEventListener','removeEventListener','bind', 'unbind', 'on', 'off', 'delegate', 'undelegate', 'removeAttr', 'compute', '_get', '___get','each'], function (name) {
+
+each(['addEventListener','removeEventListener','bind', 'unbind', 'on', 'off'], function(name) {
+	// exposing all internal canEvent evt's to canRoute
+	canRoute[name] = function() {
+		return canEvent[name].apply(eventsObject, arguments);
+	};
+});
+
+each(['delegate', 'undelegate', 'removeAttr', 'compute', '_get', '___get', 'each'], function (name) {
 	canRoute[name] = function () {
 		// `delegate` and `undelegate` require
 		// the `can/map/delegate` plugin

--- a/can-route.md
+++ b/can-route.md
@@ -92,12 +92,12 @@ You can listen to changes in a map with `on(eventName, handler(ev, args...))` an
 ### Listening to changes in can-route
 
 Listen to changes in history by [can-event.addEventListener listening] to
-changes in can-route like:
+changes in can-route's `matched` compute:
 
 ```js
-route.on('foo', function(ev, attr, how, newVal, oldVal) {
-	// Foo changed!
-})
+route.matched.on('change', function(ev, attr, how, newVal, oldVal) {
+	// attr changed from oldVal -> newVal
+});
 ```
 
  - `attr` - the name of the changed attribute

--- a/can-route.md
+++ b/can-route.md
@@ -92,7 +92,7 @@ You can listen to changes in a map with `on(eventName, handler(ev, args...))` an
 ### Listening to changes in can-route
 
 Listen to changes in history by [can-event.addEventListener listening] to
-changes in can-route's `matched` compute:
+changes of can-route's `matched` compute:
 
 ```js
 route.matched.on('change', function(ev, attr, how, newVal, oldVal) {

--- a/test/route-define-test.js
+++ b/test/route-define-test.js
@@ -1093,3 +1093,45 @@ test("param with whitespace in interpolated string (#45)", function () {
 	});
 	equal(res, "pages//baz/")
 });
+
+
+test("triggers __url event anytime a there's a change to individual properties", function(){
+	mockRoute.start();
+
+	var AppState = DefineMap.extend({seal: false},{"*": "stringOrObservable"});
+	var appState = new AppState({});
+
+	canRoute.data = appState;
+	canRoute('{page}');
+	canRoute('{page}/{section}');
+
+	QUnit.stop();
+	canRoute.ready();
+
+	var matchedCount = 0;
+	canRoute.on('__url', function() {
+		// any time a route property is changed, not just the matched route
+		matchedCount++;
+	});
+
+	setTimeout(function() {
+		canRoute.data.page = 'two';
+	}, 30);
+
+	setTimeout(function() {
+		canRoute.data.section = 'a';
+	}, 60);
+
+	setTimeout(function() {
+		canRoute.data.section = 'b';
+	}, 90);
+
+	setTimeout(function(){
+		// 1st call is going from undefined to empty string
+		equal(matchedCount, 4, 'calls __url event every time a property is changed');
+
+		mockRoute.stop();
+		QUnit.start();
+	}, 200);
+
+});

--- a/test/route-test.js
+++ b/test/route-test.js
@@ -1079,6 +1079,24 @@ test("matched() compute", function() {
 	}, 200);
 });
 
+test("triggers __url event anytime a there's a change to individual properties", function() {
+	canRoute('{page}');
+	canRoute('{page}/{section}');
+	canRoute.ready();
+
+	var matchedCount = 0;
+	canRoute.on('__url', function() {
+		// any time a route property is changed, not just the matched route
+		matchedCount++;
+	});
+
+	canRoute.data.page = 'two'; //-> fire matched event as we are in '{page}'
+	canRoute.data.section = 'a'; //-> fire matched event as we are in '{page}/{section}'
+	canRoute.data.section = 'b'; // still in '{page}/{section}', no matched event
+
+	equal(matchedCount, 3, 'calls __url event every time a property is changed');
+});
+
 //!steal-remove-start
 if (dev) {
 	test("should warn when two routes have same map properties", function () {

--- a/test/route-test.js
+++ b/test/route-test.js
@@ -1079,24 +1079,6 @@ test("matched() compute", function() {
 	}, 200);
 });
 
-test("triggers __url event anytime a there's a change to individual properties", function() {
-	canRoute('{page}');
-	canRoute('{page}/{section}');
-	canRoute.ready();
-
-	var matchedCount = 0;
-	canRoute.on('__url', function() {
-		// any time a route property is changed, not just the matched route
-		matchedCount++;
-	});
-
-	canRoute.data.page = 'two'; //-> fire matched event as we are in '{page}'
-	canRoute.data.section = 'a'; //-> fire matched event as we are in '{page}/{section}'
-	canRoute.data.section = 'b'; // still in '{page}/{section}', no matched event
-
-	equal(matchedCount, 3, 'calls __url event every time a property is changed');
-});
-
 //!steal-remove-start
 if (dev) {
 	test("should warn when two routes have same map properties", function () {


### PR DESCRIPTION
## Issue:
`route.matched.on('change', function(ev, attr, how, newVal, oldVal) {})` is only triggered when the actual route changes.

for example, consider these two routes:
1. route('{page}');
2. route('{page}/{section}');

and the following code:
```js
route.data.page = 'dog';
route.data.section = 'a';
route.data.section = 'b';
```
when route.data.section is changed the second time, the `route.matched` compute stays the same and thus it's `changed` event is not fired.

we need a way to watch for all changes to `route.data` parameters regardless of whether the matched route changes.

## Note:
all route data changes are already being triggered on the internal canEvent object [(line 248 of can-route.js)](https://github.com/canjs/can-route/blob/master/can-route.js#L248).

## Solution:
watch canRoute methods: `['addEventListener','removeEventListener','bind', 'unbind', 'on', 'off']` for `__url` events and bind them to the internal canEvent object.  

if the event method being called is not a `__url` event, revert back to binding and calling the related event on `canRoute.data`.