### PR TITLE
Make sure map decorator is only added once

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -256,20 +256,24 @@ var onRouteDataChange = function (ev, newProps, oldProps) {
 // add type coercion during Map setter to coerce all values to strings
 var stringCoercingMapDecorator = function(map) {
 
-	var attrSuper = map.attr;
+	var sym = canSymbol.for("can.route.stringCoercingMapDecorator");
+	if(!map.attr[sym]) {
+		var attrSuper = map.attr;
 
-	map.attr = function(prop, val) {
-		var serializable = this.define === undefined || this.define[prop] === undefined || !!this.define[prop].serialize,
-			args;
+		map.attr = function(prop, val) {
+			var serializable = this.define === undefined || this.define[prop] === undefined || !!this.define[prop].serialize,
+				args;
 
-		if (serializable) { // if setting non-str non-num attr
-			args = stringify(Array.apply(null, arguments));
-		} else {
-			args = arguments;
-		}
+			if (serializable) { // if setting non-str non-num attr
+				args = stringify(Array.apply(null, arguments));
+			} else {
+				args = arguments;
+			}
 
-		return attrSuper.apply(this, args);
-	};
+			return attrSuper.apply(this, args);
+		};
+		canReflect.setKeyValue(map.attr, sym, true);
+	}
 
 	return map;
 };

--- a/test/route-test.js
+++ b/test/route-test.js
@@ -1120,6 +1120,16 @@ if (dev) {
 
 		dev.warn = oldlog;
 	});
+
+	test("setting route.data with the same map doesn't add the decorator function multiple times", function () {
+		var map = new Map();
+		for(var i = 0; i < 10000; i++) {
+			canRoute.data = map;
+		}
+
+		map.attr("foo", "bar");
+		ok(true, "did not cause 'Maximum call stack size exceeded'");
+	});
 }
 //!steal-remove-end
 


### PR DESCRIPTION
This prevents possible Max call stacks by ensuring that the map
decorator is only added once. Close #92