### PR TITLE
Make sure map decorator is only added once

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -255,21 +255,24 @@ var onRouteDataChange = function (ev, newProps, oldProps) {
 // everything in the backing Map is a string
 // add type coercion during Map setter to coerce all values to strings
 var stringCoercingMapDecorator = function(map) {
+	var sym = canSymbol.for("can.route.stringCoercingMapDecorator");
+	if(!map.attr[sym]) {
+		var attrSuper = map.attr;
 
-	var attrSuper = map.attr;
+		map.attr = function(prop, val) {
+			var serializable = this.define === undefined || this.define[prop] === undefined || !!this.define[prop].serialize,
+				args;
 
-	map.attr = function(prop, val) {
-		var serializable = this.define === undefined || this.define[prop] === undefined || !!this.define[prop].serialize,
-			args;
+			if (serializable) { // if setting non-str non-num attr
+				args = stringify(Array.apply(null, arguments));
+			} else {
+				args = arguments;
+			}
 
-		if (serializable) { // if setting non-str non-num attr
-			args = stringify(Array.apply(null, arguments));
-		} else {
-			args = arguments;
-		}
-
-		return attrSuper.apply(this, args);
-	};
+			return attrSuper.apply(this, args);
+		};
+		canReflect.setKeyValue(map.attr, sym, true);
+	}
 
 	return map;
 };

--- a/test/route-test.js
+++ b/test/route-test.js
@@ -1120,6 +1120,25 @@ if (dev) {
 
 		dev.warn = oldlog;
 	});
+
+	test("setting route.data with the same map doesn't add the decorator function multiple times", function () {
+		var oldData = canRoute.data;
+		var map = new Map();
+		for(var i = 0; i < 10000; i++) {
+			canRoute.data = map;
+		}
+
+		canRoute.ready();
+
+		try {
+			map.attr("foo", "bar");
+			ok(true, "did not cause 'Maximum call stack size exceeded'");
+		} catch(err) {}
+		finally {
+			canRoute.data = oldData;
+		}
+	});
+
 }
 //!steal-remove-end
 


### PR DESCRIPTION
This prevents possible Max call stacks by ensuring that the map
decorator is only added once. Close #92