### PR TITLE
chore(package): update can-define to version 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "can-stache-key": "^0.0.2",
-    "can-define": "^1.3.0-pre.1",
+    "can-define": "^1.3.3",
     "can-list": "^3.2.0-pre.1",
     "can-map": "^3.3.1",
     "done-serve": "^0.2.0",


### PR DESCRIPTION
Fixes #82 