### PR TITLE
Fix route.ready() dev warning

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -192,7 +192,9 @@ assign(canRoute, {
 	 * ```
 	 */
 	ready: function (val) {
-		console.warn("Use can-rotue.start() instead of can-route.start()");
+		//!steal-remove-start
+		dev.warn("Use can-route.start() instead of can-route.ready()");
+		//!steal-remove-end
 		canRoute.start();
 	},
 	start: function(val){

--- a/package.json
+++ b/package.json
@@ -32,11 +32,6 @@
     "canjs-plugin",
     "donejs"
   ],
-  "steal": {
-    "configDependencies": [
-      "live-reload"
-    ]
-  },
   "dependencies": {
     "can-deparam": "^1.0.1",
     "can-event-queue": "<2.0.0",
@@ -55,7 +50,7 @@
   "devDependencies": {
     "can-define": "^2.0.0-pre.18",
     "can-map": "^4.0.0-pre.9",
-    "can-observe": "^2.0.0-pre.10",
+    "can-observe": "^2.0.0-pre.16",
     "can-stache-key": "^1.0.0-pre.12",
     "detect-cyclic-packages": "^1.1.0",
     "done-serve": "^1.5.0",


### PR DESCRIPTION
This fixes the dev warning. It was wrong in a variety of ways. Closes #128 