### PR TITLE
Make __url event test more reliable

### DIFF
--- a/test/route-define-test.js
+++ b/test/route-define-test.js
@@ -529,7 +529,7 @@ if (typeof steal !== 'undefined') {
 
 				iCanRoute.serializedCompute.unbind('change');
 				iCanRoute.serializedCompute.bind('change', function(){
-					
+
 					equal(iCanRoute.attr('personId'), '3', 'personId');
 					equal(iCanRoute.attr('foo'), undefined, 'unexpected value');
 					iCanRoute.unbind('change');
@@ -1098,7 +1098,7 @@ test("param with whitespace in interpolated string (#45)", function () {
 test("triggers __url event anytime a there's a change to individual properties", function(){
 	mockRoute.start();
 
-	var AppState = DefineMap.extend({seal: false},{"*": "stringOrObservable"});
+	var AppState = DefineMap.extend({seal: false},{"*": "stringOrObservable", page: "string", section: "string"});
 	var appState = new AppState({});
 
 	canRoute.data = appState;
@@ -1109,29 +1109,31 @@ test("triggers __url event anytime a there's a change to individual properties",
 	canRoute.start();
 
 	var matchedCount = 0;
-	canRoute.on('__url', function() {
+	var onMatchCall = {
+		1: function section_a() {
+			canRoute.data.section = 'a';
+		},
+		2: function section_b() {
+			canRoute.data.section = 'b';
+		},
+		3: function(){
+			// 1st call is going from undefined to empty string
+			equal(matchedCount, 3, 'calls __url event every time a property is changed');
+
+			canRoute.off('__url', updateMatchedCount);
+			mockRoute.stop();
+			QUnit.start();
+		}
+	};
+	var updateMatchedCount = function() {
 		// any time a route property is changed, not just the matched route
 		matchedCount++;
-	});
+		onMatchCall[matchedCount]();
+	};
+	canRoute.on('__url', updateMatchedCount);
 
-	setTimeout(function() {
+	setTimeout(function page_two() {
 		canRoute.data.page = 'two';
-	}, 30);
-
-	setTimeout(function() {
-		canRoute.data.section = 'a';
-	}, 60);
-
-	setTimeout(function() {
-		canRoute.data.section = 'b';
-	}, 90);
-
-	setTimeout(function(){
-		// 1st call is going from undefined to empty string
-		equal(matchedCount, 4, 'calls __url event every time a property is changed');
-
-		mockRoute.stop();
-		QUnit.start();
-	}, 200);
+	}, 50);
 
 });


### PR DESCRIPTION
When can-route is added to the main CanJS test suite, the `__url event` regularly fails. After running this test locally, I noticed that it either completely fails if it’s run on its own, or sometimes fails because it depends on an assertion running on a timeout after a bunch of other timeouts, e.g. the holy grail of test flakiness.

Justin refactored this test for 4.0, so I’m stealing his changes with some minor modifications.