### PR TITLE
Use can-bind internally

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "donejs"
   ],
   "dependencies": {
+    "can-bind": "<2.0.0",
     "can-deparam": "^1.0.1",
     "can-dom-events": "^1.1.0",
     "can-event-queue": "<2.0.0",


### PR DESCRIPTION
This replaces the logic for listening to the URL and route data to change with can-bind.

Closes https://github.com/canjs/can-route/issues/162