### PR TITLE
Increasing timeout for hashchange/can-map test

### DIFF
--- a/test/route-map-test.js
+++ b/test/route-map-test.js
@@ -57,7 +57,7 @@ if (typeof steal !== 'undefined') {
 			setTimeout(function () {
 
 				iframe.src = iframe.src + '#!bla=blu';
-			}, 10);
+			}, 50);
 		});
 
 	});


### PR DESCRIPTION
Bumping the timeout for this test to unblock canjs/canjs while I continue investigating why this test intermittently fails.