### PR TITLE
adding _onStartComplete to more flaky tests

### DIFF
--- a/test/define-testing.html
+++ b/test/define-testing.html
@@ -28,6 +28,17 @@
         window.DefineMap = modules[3];
         window.queues = modules[4];
         window.canReflect = modules[5];
+        /*
+        // delay start to find tests that may fail in CI
+        var origStart = route.start;
+        route.start = function() {
+        	var r = this;
+        	var args = arguments;
+        	setTimeout(function() {
+        		origStart.apply(r, args);
+        	}, 50);
+        };
+        */
         setTimeout(function () {
           window.parent.routeTestReady && window.parent.routeTestReady(route, window.location, window)
         }, 30);

--- a/test/route-define-test.js
+++ b/test/route-define-test.js
@@ -143,6 +143,13 @@ if (typeof steal !== 'undefined') {
 
 	test("updating the hash", function () {
 		setupRouteTest(function (iframe, iCanRoute, loc) {
+			iCanRoute._onStartComplete = function () {
+				var after = loc.href.substr(loc.href.indexOf("#"));
+				equal(after, "#!bar/" + encodeURIComponent("\/"));
+
+				teardownRouteTest();
+			};
+
 			iCanRoute.start();
 			iCanRoute.register("{type}/{id}");
 			iCanRoute.attr({
@@ -150,12 +157,6 @@ if (typeof steal !== 'undefined') {
 				id: "\/"
 			});
 
-			setTimeout(function () {
-				var after = loc.href.substr(loc.href.indexOf("#"));
-				equal(after, "#!bar/" + encodeURIComponent("\/"));
-
-				teardownRouteTest();
-			}, 30);
 		});
 	});
 
@@ -250,7 +251,6 @@ if (typeof steal !== 'undefined') {
 	test("routes should deep clean", function() {
 		expect(2);
 		setupRouteTest(function (iframe, iCanRoute, loc) {
-			iCanRoute.start();
 			var hash1 = canRoute.url({
 				panelA: {
 					name: "fruit",
@@ -271,13 +271,14 @@ if (typeof steal !== 'undefined') {
 
 			loc.hash = hash2;
 
-			setTimeout(function() {
+			iCanRoute._onStartComplete = function() {
 				equal(iCanRoute.data.get('panelA').id, 20, "id should change");
 				equal(iCanRoute.data.get('panelA').show, undefined, "show should be removed");
 
 				teardownRouteTest();
-			}, 30);
+			};
 
+			iCanRoute.start();
 		});
 	});
 

--- a/test/route-map-test.js
+++ b/test/route-map-test.js
@@ -142,6 +142,12 @@ if (typeof steal !== 'undefined') {
 
 	test("updating the hash", function () {
 		setupRouteTest(function (iframe, iCanRoute, loc) {
+			iCanRoute._onStartComplete = function () {
+				var after = loc.href.substr(loc.href.indexOf("#"));
+				equal(after, "#!bar/" + encodeURIComponent("\/"));
+
+				teardownRouteTest();
+			};
 
 			iCanRoute.start();
 			iCanRoute.register("{type}/{id}");
@@ -149,15 +155,6 @@ if (typeof steal !== 'undefined') {
 				type: "bar",
 				id: "\/"
 			});
-
-			setTimeout(function () {
-
-				var after = loc.href.substr(loc.href.indexOf("#"));
-				equal(after, "#!bar/" + encodeURIComponent("\/"));
-
-				teardownRouteTest();
-
-			}, 30);
 		});
 	});
 
@@ -225,6 +222,13 @@ if (typeof steal !== 'undefined') {
 	test("routes should deep clean", function() {
 		expect(2);
 		setupRouteTest(function (iframe, iCanRoute, loc) {
+			iCanRoute._onStartComplete = function() {
+				equal(iCanRoute.attr("panelA.id"), 20, "id should change");
+				equal(iCanRoute.attr("panelA.show"), undefined, "show should be removed");
+
+				teardownRouteTest();
+			};
+
 			iCanRoute.start();
 			var hash1 = canRoute.url({
 				panelA: {
@@ -241,18 +245,9 @@ if (typeof steal !== 'undefined') {
 				}
 			});
 
-
 			loc.hash = hash1;
 
 			loc.hash = hash2;
-
-			setTimeout(function() {
-				equal(iCanRoute.attr("panelA.id"), 20, "id should change");
-				equal(iCanRoute.attr("panelA.show"), undefined, "show should be removed");
-
-				teardownRouteTest();
-			}, 30);
-
 		});
 	});
 

--- a/test/testing.html
+++ b/test/testing.html
@@ -25,6 +25,17 @@
         window.observeReader = modules[2];
         window.CanMap = modules[3];
         route.data = new CanMap;
+        /*
+        // delay start to find tests that may fail in CI
+        var origStart = route.start;
+        route.start = function() {
+        	var r = this;
+        	var args = arguments;
+        	setTimeout(function() {
+        		origStart.apply(r, args);
+        	}, 50);
+        };
+        */
         setTimeout(function () {
           window.parent.routeTestReady && window.parent.routeTestReady(route, window.location, window)
         }, 30);


### PR DESCRIPTION
closes https://github.com/canjs/can-route/issues/190.