### PR TITLE
only serialize props on define that are strings

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -353,7 +353,8 @@ var stringCoercingMapDecorator = function(map) {
 		var attrSuper = map.attr;
 
 		map.attr = function(prop, val) {
-			var serializable = this.define === undefined || this.define[prop] === undefined || !!this.define[prop].serialize,
+			var serializable = typeof prop === "string" &&
+				(this.define === undefined || this.define[prop] === undefined || !!this.define[prop].serialize),
 				args;
 
 			if (serializable) { // if setting non-str non-num attr

--- a/test/route-map-test.js
+++ b/test/route-map-test.js
@@ -407,5 +407,32 @@ if (typeof require === 'undefined') {
 
 }
 
+test("Calling attr with an object should not stringify object (#197)", function () {
+	setupRouteTest(function (iframe, iCanRoute, loc, win) {
+		var app = new win.CanMap({});
+		app.define = { foo: { serialize: false } };
+
+		app.attr('foo', true);
+		equal(app.attr('foo'), true, 'not route data - .attr("foo", ...) works');
+
+		app.attr({
+			foo: false
+		});
+		equal(app.attr('foo'), false, 'not route data - .attr({"foo": ...}) works');
+
+		iCanRoute.data = app;
+
+		app.attr('foo', true);
+		equal(app.attr('foo'), true, 'route data - .attr("foo", ...) works');
+
+		app.attr({
+			foo: false
+		});
+		equal(app.attr('foo'), false, 'route data - .attr({"foo": ...}) works');
+
+		teardownRouteTest();
+	});
+});
+
 
 }


### PR DESCRIPTION
This makes sure that objects, and thus their key/value pairs are not stringified when can-route.data changes.