### PR TITLE
Make DefineMap the default route.data

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -9,7 +9,8 @@ var devLog = require('can-log/dev/dev');
 var canReflect = require('can-reflect');
 var canSymbol = require('can-symbol');
 var makeCompute = require("can-simple-observable/make-compute/make-compute");
-var SimpleMap = require("can-simple-map");
+var RouteData = require("./src/routedata");
+var stringCoercingMapDecorator = require("./src/string-coercion").stringCoercingMapDecorator;
 
 var registerRoute = require("./src/register");
 var urlHelpers = require("./src/url-helpers");
@@ -323,53 +324,6 @@ Object.defineProperty(canRoute,"serializedCompute", {
 		return serializedCompute;
 	}
 });
-// Helper for convert any object (or value) to stringified object (or value)
-var stringify = function (obj) {
-	// Object is array, plain object, Map or List
-	if (obj && typeof obj === "object") {
-		if (obj && typeof obj === "object" && ("serialize" in obj)) {
-			obj = obj.serialize();
-		} else {
-			// Get array from array-like or shallow-copy object
-			obj = typeof obj.slice === "function" ? obj.slice() : canReflect.assign({}, obj);
-		}
-		// Convert each object property or array item into stringified new
-		canReflect.eachKey(obj, function (val, prop) {
-			obj[prop] = stringify(val);
-		});
-		// Object supports toString function
-	} else if (obj !== undefined && obj !== null && (typeof obj.toString === "function" )) {
-		obj = obj.toString();
-	}
-
-	return obj;
-};
-// everything in the backing Map is a string
-// add type coercion during Map setter to coerce all values to strings so unexpected conflicts don't happen.
-// https://github.com/canjs/canjs/issues/2206
-var stringCoercingMapDecorator = function(map) {
-	var sym = canSymbol.for("can.route.stringCoercingMapDecorator");
-	if(!map.attr[sym]) {
-		var attrSuper = map.attr;
-
-		map.attr = function(prop, val) {
-			var serializable = typeof prop === "string" &&
-				(this.define === undefined || this.define[prop] === undefined || !!this.define[prop].serialize),
-				args;
-
-			if (serializable) { // if setting non-str non-num attr
-				args = stringify(Array.apply(null, arguments));
-			} else {
-				args = arguments;
-			}
-
-			return attrSuper.apply(this, args);
-		};
-		canReflect.setKeyValue(map.attr, sym, true);
-	}
-
-	return map;
-};
 
 var viewModelSymbol = canSymbol.for("can.viewModel");
 Object.defineProperty(canRoute,"data", {
@@ -377,7 +331,7 @@ Object.defineProperty(canRoute,"data", {
 		if(routeData) {
 			return routeData;
 		} else {
-			return setRouteData( stringCoercingMapDecorator( new SimpleMap() ) );
+			return setRouteData(new RouteData());
 		}
 	},
 	set: function(data) {

--- a/package.json
+++ b/package.json
@@ -50,16 +50,16 @@
     "can-queues": "<2.0.0",
     "can-reflect": "^1.16.7",
     "can-route-hash": "<2.0.0",
-    "can-simple-map": "^4.0.0",
     "can-simple-observable": "^2.0.0",
     "can-string": "<2.0.0",
     "can-symbol": "^1.0.0"
   },
   "devDependencies": {
-    "can-define": "^2.0.0",
+    "can-define": "^2.6.0",
     "can-map": "^4.0.0",
     "can-observe": "^2.0.0",
     "can-route-mock": "<2.0.0",
+    "can-simple-map": "^4.0.0",
     "can-stache-key": "^1.0.0",
     "can-test-helpers": "^1.1.2",
     "detect-cyclic-packages": "^1.1.0",

--- a/src/register.js
+++ b/src/register.js
@@ -9,6 +9,7 @@ var regexps = require("./regexps");
 
 var diff = require('can-diff/list/list');
 var diffObject = require('can-diff/map/map');
+var RouteData = require("./routedata");
 // `RegExp` used to match route variables of the type '{name}'.
 // Any word character or a period is matched.
 
@@ -95,6 +96,17 @@ var RouteRegistry = {
 	    		}
 	    	});
     	}
+
+			// Assign to the instance props
+			if(this.data instanceof RouteData) {
+				var routeData = this.data;
+				canReflect.eachIndex(names, function(name) {
+					canReflect.defineInstanceKey(routeData.constructor, name, {
+						type: "string"
+					});
+				});
+			}
+
     	//!steal-remove-end
     	// Add route in a form that can be easily figured out.
     	return RouteRegistry.routes[url] = {

--- a/src/register.js
+++ b/src/register.js
@@ -102,9 +102,10 @@ var RouteRegistry = {
 				var routeData = this.data;
 				canReflect.eachIndex(names, function(name) {
 					var type = "string";
-					var typeOf = typeof defaults[name];
+					var defaultValue = defaults[name];
+					var typeOf = typeof defaultValue;
 
-					if(typeOf !== "undefined") {
+					if(defaultValue != null) {
 						type = typeOf;
 					}
 

--- a/src/register.js
+++ b/src/register.js
@@ -101,8 +101,15 @@ var RouteRegistry = {
 			if(this.data instanceof RouteData) {
 				var routeData = this.data;
 				canReflect.eachIndex(names, function(name) {
+					var type = "string";
+					var typeOf = typeof defaults[name];
+
+					if(typeOf !== "undefined") {
+						type = typeOf;
+					}
+
 					canReflect.defineInstanceKey(routeData.constructor, name, {
-						type: "string"
+						type: type
 					});
 				});
 			}

--- a/src/routedata.js
+++ b/src/routedata.js
@@ -1,0 +1,8 @@
+var DefineMap = require("can-define/map/map");
+var stringify = require("./string-coercion").stringify;
+
+module.exports = DefineMap.extend("RouteData", { seal: false }, {
+	"*": {
+		type: stringify
+	}
+});

--- a/src/string-coercion.js
+++ b/src/string-coercion.js
@@ -1,0 +1,54 @@
+var canReflect = require("can-reflect");
+var canSymbol = require("can-symbol");
+
+// Helper for convert any object (or value) to stringified object (or value)
+var stringify = function (obj) {
+	// Object is array, plain object, Map or List
+	if (obj && typeof obj === "object") {
+		if (obj && typeof obj === "object" && ("serialize" in obj)) {
+			obj = obj.serialize();
+		} else {
+			// Get array from array-like or shallow-copy object
+			obj = typeof obj.slice === "function" ? obj.slice() : canReflect.assign({}, obj);
+		}
+		// Convert each object property or array item into stringified new
+		canReflect.eachKey(obj, function (val, prop) {
+			obj[prop] = stringify(val);
+		});
+		// Object supports toString function
+	} else if (obj !== undefined && obj !== null && (typeof obj.toString === "function" )) {
+		obj = obj.toString();
+	}
+
+	return obj;
+};
+
+// everything in the backing Map is a string
+// add type coercion during Map setter to coerce all values to strings so unexpected conflicts don't happen.
+// https://github.com/canjs/canjs/issues/2206
+var stringCoercingMapDecorator = function(map) {
+	var sym = canSymbol.for("can.route.stringCoercingMapDecorator");
+	if(!map.attr[sym]) {
+		var attrSuper = map.attr;
+
+		map.attr = function(prop, val) {
+			var serializable = typeof prop === "string" &&
+				(this.define === undefined || this.define[prop] === undefined || !!this.define[prop].serialize),
+				args;
+
+			if (serializable) { // if setting non-str non-num attr
+				args = stringify(Array.apply(null, arguments));
+			} else {
+				args = arguments;
+			}
+
+			return attrSuper.apply(this, args);
+		};
+		canReflect.setKeyValue(map.attr, sym, true);
+	}
+
+	return map;
+};
+
+exports.stringCoercingMapDecorator = stringCoercingMapDecorator;
+exports.stringify = stringify;

--- a/test/mock-route-binding.js
+++ b/test/mock-route-binding.js
@@ -1,5 +1,5 @@
 var canRoute = require("can-route");
-var SimpleMap = require("can-simple-map");
+var RouteData = require("../src/routedata");
 
 var RouteMock = require("can-route-mock");
 
@@ -13,7 +13,7 @@ module.exports = {
         canRoute.urlData = this.hash;
 
 		this.hash.value = "";
-		canRoute.data = new SimpleMap();
+		canRoute.data = new RouteData();
 		//canRoute._setup();
 	},
 	stop: function(){
@@ -21,7 +21,7 @@ module.exports = {
         canRoute.urlData = oldDefault;
 
 		this.hash = new RouteMock();
-		canRoute.data = new SimpleMap();
+		canRoute.data = new RouteData();
 		//canRoute.bindings.mock.unbind();
 		//canRoute._setup();
 	}

--- a/test/route-data-test.js
+++ b/test/route-data-test.js
@@ -2,6 +2,7 @@ var canRoute = require('can-route');
 var QUnit = require('steal-qunit');
 var SimpleMap = require("can-simple-map");
 var canSymbol = require("can-symbol");
+var mockRoute = require("./mock-route-binding");
 
 require('can-observation');
 
@@ -24,4 +25,23 @@ test("can-route.data can be set to an element with a viewModel", function(){
 
 
     QUnit.equal(canRoute.data, vm, "works");
+});
+
+
+QUnit.asyncTest("Default map registers properties", function(){
+	mockRoute.start();
+
+	canRoute.register("{type}/{id}");
+
+	canRoute._onStartComplete = function () {
+		var after = mockRoute.hash.get();
+		equal(after, "cat/5", "same URL");
+		equal(canRoute.data.type, "cat", "conflicts should be won by the URL");
+		equal(canRoute.data.id, "5", "conflicts should be won by the URL");
+		QUnit.start();
+		mockRoute.stop();
+	};
+
+	mockRoute.hash.value = "#!cat/5";
+	canRoute.start();
 });

--- a/test/route-data-test.js
+++ b/test/route-data-test.js
@@ -45,3 +45,21 @@ QUnit.asyncTest("Default map registers properties", function(){
 	mockRoute.hash.value = "#!cat/5";
 	canRoute.start();
 });
+
+QUnit.asyncTest("Property defaults influence the Type", function(){
+	mockRoute.start();
+
+	canRoute.register("{type}/{id}", { type: "dog", "id": 14});
+
+	canRoute._onStartComplete = function () {
+		var after = mockRoute.hash.get();
+		equal(after, "cat/7", "same URL");
+		equal(canRoute.data.type, "cat", "conflicts should be won by the URL");
+		deepEqual(canRoute.data.id, 7, "conflicts should be won by the URL");
+		QUnit.start();
+		mockRoute.stop();
+	};
+
+	mockRoute.hash.value = "#!cat/7";
+	canRoute.start();
+});

--- a/test/route-data-test.js
+++ b/test/route-data-test.js
@@ -49,17 +49,18 @@ QUnit.asyncTest("Default map registers properties", function(){
 QUnit.asyncTest("Property defaults influence the Type", function(){
 	mockRoute.start();
 
-	canRoute.register("{type}/{id}", { type: "dog", "id": 14});
+	canRoute.register("{type}/{id}/{more}", { type: "dog", "id": 14, more: null });
 
 	canRoute._onStartComplete = function () {
 		var after = mockRoute.hash.get();
-		equal(after, "cat/7", "same URL");
+		equal(after, "cat/7/stuff", "same URL");
 		equal(canRoute.data.type, "cat", "conflicts should be won by the URL");
 		deepEqual(canRoute.data.id, 7, "conflicts should be won by the URL");
+		deepEqual(canRoute.data.more, "stuff", "null defaults are converted");
 		QUnit.start();
 		mockRoute.stop();
 	};
 
-	mockRoute.hash.value = "#!cat/7";
+	mockRoute.hash.value = "#!cat/7/stuff";
 	canRoute.start();
 });


### PR DESCRIPTION
This changes makes DefineMap the default route.data. Calls to
`route.register("{page}")` will automatically define those properties so
that they are accessible via `route.data.page`.