### PR TITLE
Fixing documentation issues

### DIFF
--- a/doc/can-route.md
+++ b/doc/can-route.md
@@ -16,24 +16,24 @@
   the can-route export:
 
   ```js
-{
-	data,     // The bound key-value observable.
-    urlData,  // The observable that represents the
+  {
+      data,     // The bound key-value observable.
+      urlData,  // The observable that represents the
               // hash. Defaults to RouteHash.
-	register, // Register routes that translate between
-	          // the url and the bound observable.
-	start,    // Begin updating the bound observable with
-	          // url data and vice versa.
-	deparam,  // Given url fragment, return the data for it.
-	rule,     // Given url fragment, return the routing rule
-	param,    // Given data, return a url fragment.
-	url,      // Given data, return a url for it.
-	link,     // Given data, return an <a> tag for it.
-	isCurrent,   // Given data, return true if the current url matches
-	             // the data.
-	currentRule // Return the matched rule name.
-}
-```
+      register, // Register routes that translate between
+              // the url and the bound observable.
+      start,    // Begin updating the bound observable with
+              // url data and vice versa.
+      deparam,  // Given url fragment, return the data for it.
+      rule,     // Given url fragment, return the routing rule
+      param,    // Given data, return a url fragment.
+      url,      // Given data, return a url for it.
+      link,     // Given data, return an <a> tag for it.
+      isCurrent,   // Given data, return true if the current url matches
+                  // the data.
+      currentRule // Return the matched rule name.
+  }
+  ```
 
 @body
 
@@ -49,7 +49,7 @@ without changing the page.
 
 This provides the basics needed to
 create history enabled single-page apps.  However,
-`route` addresses several other needs aswell, such as:
+`route` addresses several other needs as well, such as:
 
   - Pretty urls.
   - Keeping routes independent of application code.
@@ -78,38 +78,47 @@ Typically, the map is the view-model of the top-level [can-component] in your
 application.  For example, the following defines `<my-app>`, and uses the view-model
 of a `<my-app>` element already in the page as the `route.data`:
 
-```js
-import Component from "can-component";
-import route from "can-route";
-import "can-stache-route-helpers";
+```html
+<mock-url>
+<my-app>
+<script>
+  import {DefineMap, Component, route, stacheRouteHelpers} from "can";
+  // import {PageHome} from "//unpkg.com/route-mini-app@^5.0.0/components.mjs";
+  import "//unpkg.com/mock-url@^5.0.0/mock-url.mjs";
 
-Component.extend({
+  const PageHome = Component.extend({
+    tag: "page-home",
+    view: `<h1>home page</h1>`,
+    ViewModel: {},
+  });
+
+  Component.extend({
     tag: "my-app",
     ViewModel: {
-        page: "string"
+      routeData: {
+        default() {
+          const observableRouteData = new DefineMap();
+          route.data = observableRouteData;
+          route.register("{page}", { page: "home" });
+          route.start();
+          return observableRouteData;
+        }
+      },
+      get componentToShow() {
+        switch(this.routeData.page) {
+          case "home":
+            return new PageHome();
+        }
+      },
+      page: "string"
     },
     view: `
-        {{#switch(page)}}
-            {{#case("home")}}
-                <h1>Home Page</h1>
-                <a href="{{#routeUrl(page='products')}}">Products</a>
-            {{/case}}
-            {{#case("products")}}
-                <h1>Products</h1>
-                <a href="{{#routeUrl(page='home')}}">Home</a>
-            {{/case}}
-            {{#default()}}
-                <h1>Page Not Found</h1>
-                <a href="{{#routeUrl(page='home')}}">Home</a>
-            {{/default}}
-        {{/switch}}
+      {{componentToShow}}
     `
-});
-
-route.data = document.querySelector( "my-app" );
-route.register( "{page}" );
-route.start();
+  });
+</script>
 ```
+@codepen
 
 > __Note__: The `route.data = document.querySelector("my-app")` statement is what
 > sets `route.data` to `<my-app>`'s view-model.
@@ -118,8 +127,7 @@ An observable can be set as `route.data` directly.  The following sets `route.da
 to an `AppViewModel` instance:
 
 ```js
-import DefineMap from "can-define/map/map";
-import route from "can-route";
+import {DefineMap, route} from "can";
 
 const AppViewModel = DefineMap.extend( {
 	page: "string"

--- a/doc/currentRule.md
+++ b/doc/currentRule.md
@@ -3,18 +3,16 @@
 @description A compute representing the currently matched routing rule route.
 
 @signature `route.currentRule()`
-@return {String} The currently matched [can-route.register registered] routing rule.
+  Use `route.currentRule()` to find the current route rule.
 
-@body
+  ```js
+  import {route} from "can";
+  route.register( "{type}", { type: "foo" } );
+  route.register( "{type}/{subtype}" );
+  console.log( route.currentRule() ); //-> "{type}"
+  route.data.subtype = "bar";
+  console.log( route.currentRule() ); //-> "{type}/{subtype}"
+  ```
+  @codepen
 
-## Use
-
-Use `route.currentRule()` to find the current route rule.
-
-```js
-route.register( "{type}", { type: "foo" } );
-route.register( "{type}/{subtype}" );
-route.currentRule(); // "{type}"
-route.data.subtype = "foo";
-route.currentRule(); // "{type}/{subtype}"
-```
+  @return {String} The currently matched [can-route.register registered] routing rule.

--- a/doc/currentRule.md
+++ b/doc/currentRule.md
@@ -7,9 +7,13 @@
 
   ```js
   import {route} from "can";
-  route.register( "{type}", { type: "foo" } );
+
+  route.register( "{type}" );
   route.register( "{type}/{subtype}" );
+
+  route.data.type = "foo";
   console.log( route.currentRule() ); //-> "{type}"
+
   route.data.subtype = "bar";
   console.log( route.currentRule() ); //-> "{type}/{subtype}"
   ```

--- a/doc/currentRule.md
+++ b/doc/currentRule.md
@@ -10,12 +10,18 @@
 
   route.register( "{type}" );
   route.register( "{type}/{subtype}" );
+  route.start();
 
   route.data.type = "foo";
-  console.log( route.currentRule() ); //-> "{type}"
+  setTimeout(() => {
+    console.log( route.currentRule() ); //-> "{type}"
+    
+    route.data.subtype = "bar";
+  }, 100);
 
-  route.data.subtype = "bar";
-  console.log( route.currentRule() ); //-> "{type}/{subtype}"
+  setTimeout(() => {
+    console.log( route.currentRule() ); //-> "{type}/{subtype}"
+  }, 200);
   ```
   @codepen
 

--- a/doc/data.md
+++ b/doc/data.md
@@ -5,7 +5,7 @@ An observable key-value object used to cross bind to the url observable [can-rou
 
 @type {Object} If `route.data` is set to a [can-reflect]ed observable object of
 key-value pairs, once [can-route.start] is called, changes in `route.data`'s
-properties will update the hash and vice-versa.
+properties will update the hash and vice-versa. `route.data` defaults to a [can-define/map/map].
 
   ```html
   <mock-url></mock-url>
@@ -44,66 +44,16 @@ to the browser's hash.
 
 For in-depth examples see the the [guides/routing Routing] guide.
 
-## Background
-
-One of the biggest challenges in a complex application is getting all the different parts of the app to talk to each other simply, cleanly, and reliably.
-
-An elegant way to solve this problem is using the [Observer Pattern](http://en.wikipedia.org/wiki/Observer_pattern). A single object, which can be called [Application ViewModel](https://www.youtube.com/watch?v=LrzK4exG5Ss), holds the high level state of the application.
-
 ## Use
 
-Setting `route.data` is an easy way to cross-bind your Application ViewModel object to `route`. This will serialize your Application ViewModel into the hash (or pushstate URLs).
+`route.data` defaults to [can-define/map/map], but `route.data` can be set to any observable. The following uses [can-observe]:
 
 ```js
-import {DefineMap} from "can";
+import {DefineMap, route, observe} from "can/everything";
 
-const ViewModel = DefineMap.extend( {
-  petType: "string",
-  storeId: "number"
-} );
-
-const viewModel = new ViewModel( {
-  petType: "string",
-  storeId: "number"
-} );
-
-route.data = viewModel;
+route.data = new observe();
+route.register( "{page}", { page: "home" } );
+route.start();
+console.log( route.data.page ) //-> "home"
 ```
-
-`route.data` can also be set to a constructor function. A new instance will be created and bound to:
-
-```js
-import {DefineMap, route} from "can";
-
-const ViewModel = DefineMap.extend( {
-  page: {
-    type: "string",
-    set( page ) {
-      if ( page === "user" ) {
-        this.verifyLoggedIn();
-      }
-      return page;
-    }
-  }
-} );
-
-route.data = ViewModel;
-```
-
-## When to set it
-
-Set `route.data` at the  start of the application lifecycle, before any calls to `route.addEventListener`. This will allow events to correctly bind on this new object.
-
-## Demo
-
-The following shows creating an Application ViewModel that loads data at page load, has a virtual property 'locationIds' which serializes an array, and synchronizes the viewModel to can-route:
-
-@demo demos/can-route/data.html
-
-## Why
-
-The Application ViewModel object, which is cross-bound to the can-route via `route.data` and represents the overall state of the application, has several obvious uses:
-
-* It is passed into the various components and used to communicate their own internal state.
-* It provides deep linking and back button support. As the URL changes, Application ViewModel changes cause changes in application components.
-* It provides the ability to "save" the current state of the page, by serializing the Application ViewModel object and saving it on the backend, then restoring with that object to load this saved state.
+@codepen

--- a/doc/data.md
+++ b/doc/data.md
@@ -35,7 +35,7 @@ to the browser's hash.
     <div class="deprecated warning">
     <h3>Deprecated</h3>
     <div class="signature-wrapper">
-    <p>Assigning an [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) to `route.data` has been deprecated in favor of setting it to an observable. If you have any further questions please refer to the [guides/routing Routing] guide.
+    <p>Assigning an <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement">HTMLElement</a> to <code>route.data</code> has been deprecated in favor of setting it to an observable. If you have any further questions please refer to the [guides/routing Routing] guide.
     </div>
     </div>
   </section>

--- a/doc/deparam.md
+++ b/doc/deparam.md
@@ -5,47 +5,63 @@
 
 @signature `route.deparam(url)`
 
-Extract data from a url, creating an object representing its values.
+  Extract data from a url, creating an object representing its values.
 
-```js
-route.register("{page}");
+  ```js
+  import {route} from "can";
 
-const result = route.deparam("page=home");
-console.log(result.page); // -> "home"
-```
+  const result = route.deparam("page=home");
+  console.log( result.page ); //-> "home"
+  ```
+  @codepen
 
-@param {String} url A route fragment to extract data from.
-@return {Object} An object containing the extracted data.
+  @param {String} url A route fragment to extract data from.
+  @return {Object} An object containing the extracted data.
 
 @body
 
-Creates a data object based on the query string passed into it. This is
-useful to create an object based on the `location.hash`.
+Creates a data object based on the query string passed into it. This is useful to create an object based on the `location.hash`.
 
 ```js
-route.deparam("id=5&type=videos");
-  // -> { id: 5, type: "videos" }
+import {route} from "can";
+
+const result = route.deparam("id=5&type=videos"); 
+console.log( result ); //-> { id: 5, type: "videos" }
 ```
+@codepen
 
-It's important to make sure the hash or exclamation point is not passed
-to `route.deparam` otherwise it will be included in the first property's
-name.
+It's important to make sure the hash or exclamation point is not passed to `route.deparam` otherwise it will be included in the first property's name.
 
-```js
-route.data.id = 5 // location.hash -> #!id=5
-route.data.type = "videos"
-  // location.hash -> #!id=5&type=videos
-route.deparam(location.hash);
-  // -> { #!id: 5, type: "videos" }
+```html
+<mock-url></mock-url>
+<script>
+import "//unpkg.com/mock-url@^5.0.0";
+import {route} from "//unpkg.com/can@5/core.mjs";
+
+route.data = {};
+route.register("")
+route.data.id = 5;  // location.hash -> #!id=5
+route.data.type = "videos"; // location.hash -> #!&id=5&type=videos
+
+route.start();
+
+// setting datatype is synchronous
+setTimeout(() => {
+  const result = route.deparam(location.hash);
+  console.log( result ); //-> { id: 5, type: "videos" }
+}, 300);
+</script>
 ```
+@codepen
 
-`route.deparam` will try and find a matching route and, if it does,
-will deconstruct the URL and parse out the key/value parameters into the
-data object.
+`route.deparam` will try and find a matching route and, if it does, will deconstruct the URL and parse out the key/value parameters into the data object.
 
 ```js
+import {route} from "can";
+
 route.register("{type}/{id}");
 
-route.deparam("videos/5");
-  // -> { id: 5, route: "{type}/{id}", type: "videos" }
+const result = route.deparam("videos/5");
+console.log( result ); //-> { id: 5, type: "videos" }
 ```
+@codepen

--- a/doc/deparam.md
+++ b/doc/deparam.md
@@ -5,7 +5,7 @@
 
 @signature `route.deparam(url)`
 
-  Extract data from a url, creating an object representing its values.
+  Extract data from a url fragment, creating an object representing its values. The url fragment could be a [location.hash](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/hash) or [location.search](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/search).
 
   ```js
   import {route} from "can";
@@ -20,7 +20,9 @@
 
 @body
 
-Creates a data object based on the query string passed into it. This is useful to create an object based on the `location.hash`.
+## Use
+
+`route.deparam` creates a data object based on the query string passed into it. This is useful to create an object based on the `location.hash`.
 
 ```js
 import {route} from "can";
@@ -36,7 +38,7 @@ It's important to make sure the hash or exclamation point is not passed to `rout
 <mock-url></mock-url>
 <script type="module">
 import "//unpkg.com/mock-url@^5.0.0";
-import {route} from "//unpkg.com/can@5/core.mjs";
+import {route} from "can";
 
 route.data = {};
 route.register("")

--- a/doc/deparam.md
+++ b/doc/deparam.md
@@ -30,11 +30,11 @@ console.log( result ); //-> { id: 5, type: "videos" }
 ```
 @codepen
 
-It's important to make sure the hash or exclamation point is not passed to `route.deparam` otherwise it will be included in the first property's name.
+It's important to make sure the hash or exclamation point is not passed to `route.deparam` otherwise it will be included as a property.
 
 ```html
 <mock-url></mock-url>
-<script>
+<script type="module">
 import "//unpkg.com/mock-url@^5.0.0";
 import {route} from "//unpkg.com/can@5/core.mjs";
 
@@ -48,7 +48,7 @@ route.start();
 // setting datatype is synchronous
 setTimeout(() => {
   const result = route.deparam(location.hash);
-  console.log( result ); //-> { id: 5, type: "videos" }
+  console.log( result ); //-> { #!: "", id: "5", type: "videos" }
 }, 300);
 </script>
 ```

--- a/doc/isCurrent.md
+++ b/doc/isCurrent.md
@@ -11,7 +11,7 @@
   ```js
   import {route} from "//unpkg.com/can@5/core.mjs";
 
-  route.data =  {page: "recipes", id: "5"};
+  route.data =  {page: "recipes", id: "5"}; // location.hash -> "#!&page=recipes&id=5"
   route.start();
 
   setTimeout(() => {
@@ -54,12 +54,12 @@ setTimeout(() => {
   const checkFullRoute = route.isCurrent( {id: 5, type: "videos"} );
   console.log(checkFullRoute); // -> false
   
-  route.data.type = "videos";
+  route.data.type = "videos"; // location.hash -> "#!&id=5&type=videos"
   route.start();
 }, 100);
 
 setTimeout(() => {
-  const checkFullRoute = route.isCurrent( {id: 5, type: "videos" } );
+  const checkFullRoute = route.isCurrent( {id: 5, type: "videos"} );
   console.log( checkFullRoute ); //-> true
 }, 200);
 

--- a/doc/isCurrent.md
+++ b/doc/isCurrent.md
@@ -8,8 +8,10 @@
   Compares `data` to the current route. Used to verify if an object is
   representative of the current route.
 
+  The following example calls `route.isCurrent` with a single matching parameter when `route.data` has two properties. If `subsetMatch` is `false` or left default `route.isCurrent` won't try and match subsets.
+
   ```js
-  import {route} from "//unpkg.com/can@5/core.mjs";
+  import {route} from "can";
 
   route.data =  {page: "recipes", id: "5"}; // location.hash -> "#!&page=recipes&id=5"
   route.start();
@@ -30,38 +32,3 @@
   the route data has additional properties that are not matched.  Defaults to `false`
   where every property needs to be present.
   @return {Boolean} Whether the data matches the current URL.
-
-@body
-
-## Use
-
-Checks the page's current URL to see if the route represents the options
-passed into the function.
-
-Returns true if the options represent the current URL.
-
-```js
-import {route} from "//unpkg.com/can@5/core.mjs";
-
-route.data = {};
-route.data.id = 5; // location.hash -> "#!&id=5"
-route.start();
-
-setTimeout(() => {
-  const currentId = route.isCurrent( { id: "5" } );
-  console.log(currentId); // -> true
-
-  const checkFullRoute = route.isCurrent( {id: 5, type: "videos"} );
-  console.log(checkFullRoute); // -> false
-  
-  route.data.type = "videos"; // location.hash -> "#!&id=5&type=videos"
-  route.start();
-}, 100);
-
-setTimeout(() => {
-  const checkFullRoute = route.isCurrent( {id: 5, type: "videos"} );
-  console.log( checkFullRoute ); //-> true
-}, 200);
-
-```
-@codepen

--- a/doc/isCurrent.md
+++ b/doc/isCurrent.md
@@ -1,21 +1,30 @@
 @function can-route.isCurrent isCurrent
 @parent can-route.static
 
-Check if data represents the current route.
+@description Check if data represents the current route.
 
 @signature `route.isCurrent(data [,subsetMatch] )`
 
-Compares `data` to the current route. Used to verify if an object is
-representative of the current route.
+  Compares `data` to the current route. Used to verify if an object is
+  representative of the current route.
 
-```js
-route.data.set({page: "recipes", id: '5'});
+  ```js
+  import {route} from "//unpkg.com/can@5/core.mjs";
 
-route.isCurrent({page: "recipes"});       //-> false
-route.isCurrent({page: "recipes"}, true); //-> true
-```
+  route.data =  {page: "recipes", id: "5"};
+  route.start();
 
-  @param {Object} data Data to check agains the current route.
+  setTimeout(() => {
+    const completeSet = route.isCurrent( {page: "recipes"} );
+    console.log( completeSet ); //-> false
+
+    const subSet = route.isCurrent( {page: "recipes"}, true );
+    console.log( subSet ); //-> true
+  }, 200);
+  ```
+  @codepen
+
+  @param {Object} data Data to check against the current route.
   @param {Boolean} [subsetMatch] If true, `route.current` will return true
   if every value in `data` matches the current route data, even if
   the route data has additional properties that are not matched.  Defaults to `false`
@@ -32,11 +41,27 @@ passed into the function.
 Returns true if the options represent the current URL.
 
 ```js
-route.data.id = 5; // location.hash -> "#!id=5"
-route.isCurrent({ id: 5 }); // -> true
-route.isCurrent({ id: 5, type: 'videos' }); // -> false
+import {route} from "//unpkg.com/can@5/core.mjs";
 
-route.data.type = 'videos';
-  // location.hash -> #!id=5&type=videos
-route.isCurrent({ id: 5, type: 'videos' }); // -> true
+route.data = {};
+route.data.id = 5; // location.hash -> "#!&id=5"
+route.start();
+
+setTimeout(() => {
+  const currentId = route.isCurrent( { id: "5" } );
+  console.log(currentId); // -> true
+
+  const checkFullRoute = route.isCurrent( {id: 5, type: "videos"} );
+  console.log(checkFullRoute); // -> false
+  
+  route.data.type = "videos";
+  route.start();
+}, 100);
+
+setTimeout(() => {
+  const checkFullRoute = route.isCurrent( {id: 5, type: "videos" } );
+  console.log( checkFullRoute ); //-> true
+}, 200);
+
 ```
+@codepen

--- a/doc/link.md
+++ b/doc/link.md
@@ -5,33 +5,39 @@
 
 @signature `route.link(innerText, data, props [, merge])`
 
-Make an anchor tag (`<a>`) that when clicked on will update can-route's
-properties to match those in `data`.
+  Make an anchor tag (`<a>`) that when clicked on will update can-route's properties to match those in `data`. Creates and returns an anchor tag with an href of the route attributes passed into it, as well as any properties desired for the tag.
 
-@param {Object} innerText The text inside the link.
-@param {Object} data The data to populate the route with.
-@param {Object} props Properties for the anchor other than `href`.
-@param {Boolean} [merge] Whether the given options should be merged into the current state of the route.
-@return {String} A string with an anchor tag that points to the populated route.
+  ```js
+  import {route} from "can";
+
+  const link = route.link( "My videos", { type: "videos" }, {}, false );
+  console.log( link ); //-> '<a href="#!&type=videos">My Videos</a>'
+  ```
+  @codepen
+
+  @param {Object} innerText The text inside the link.
+  @param {Object} data The data to populate the route with.
+  @param {Object} props Properties for the anchor other than `href`.
+
+  Other attributes besides href can be added to the anchor tag by passing in a data object with the attributes desired.
+
+   ```js
+   import {route} from "can";
+
+   const link = route.link( 
+     "My videos", 
+     { type: "videos" },
+     { className: "new" },
+     false
+   );
+   console.log( link ); //-> '<a href="#!&type=videos" class="new">My Videos</a>'
+   ```
+   @codepen
+
+  @param {Boolean} [merge] Whether the given options should be merged into the current state of the route.
+  @return {String} A string with an anchor tag that points to the populated route.
 
 @body
-Creates and returns an anchor tag with an href of the route
-attributes passed into it, as well as any properties desired
-for the tag.
-
-```js
-route.link( "My videos", { type: "videos" }, {}, false )
-  // -> <a href="#!type=videos">My videos</a>
-```
-
-Other attributes besides href can be added to the anchor tag
-by passing in a data object with the attributes desired.
-
-```js
-route.link( "My videos", { type: "videos" },
-  { className: "new" }, false )
-    // -> <a href="#!type=videos" class="new">My Videos</a>
-```
 
 It is possible to utilize the current route options when making anchor
 tags in order to make your code more reusable. If merge is set to true,
@@ -39,11 +45,14 @@ the route options passed into `canRoute.link` will be passed into the
 current ones.
 
 ```js
-location.hash = "#!type=videos"
-route.link( "The zoo", { id: 5 }, true )
-  // -> <a href="#!type=videos&id=5">The zoo</true>
+import {route} from "can";
 
-location.hash = "#!type=pictures"
-route.link( "The zoo", { id: 5 }, true )
-  // -> <a href="#!type=pictures&id=5">The zoo</true>
+location.hash = "#!type=videos";
+const videoLink = route.link( "The zoo", { id: 5 }, {}, true );
+console.log( videoLink ); // -> <a href="#!&type=videos&id=5">The zoo</a>
+
+location.hash = "#!type=pictures";
+const pictureLink = route.link( "The zoo", { id: 5 }, {}, true );
+console.log( pictureLink ); // -> <a href="#!&type=pictures&id=5">The zoo</a>
 ```
+@codepen

--- a/doc/link.md
+++ b/doc/link.md
@@ -1,7 +1,16 @@
 @function can-route.link link
-@parent can-route.static
+@parent can-route.deprecated
 
 @description Creates a string representation of an anchor link using data and the registered routes.
+
+<section class="warnings">
+  <div class="deprecated warning">
+  <h3>Deprecated 4.4.1</h3>
+  <div class="signature-wrapper">
+  <p><code>route.link</code> has been deprecated in favor of <a href="can-stache-route-helpers.routeUrl.html" title="Returns a url using route.url.">can-stache-route-helpers.routeCurrent</a>.
+  </div>
+  </div>
+</section>
 
 @signature `route.link(innerText, data, props [, merge])`
 
@@ -38,6 +47,8 @@
   @return {String} A string with an anchor tag that points to the populated route.
 
 @body
+
+## Use
 
 It is possible to utilize the current route options when making anchor
 tags in order to make your code more reusable. If merge is set to true,

--- a/doc/link.md
+++ b/doc/link.md
@@ -49,10 +49,10 @@ import {route} from "can";
 
 location.hash = "#!type=videos";
 const videoLink = route.link( "The zoo", { id: 5 }, {}, true );
-console.log( videoLink ); // -> <a href="#!&type=videos&id=5">The zoo</a>
+console.log( videoLink ); //-> <a href="#!&type=videos&id=5">The zoo</a>
 
 location.hash = "#!type=pictures";
 const pictureLink = route.link( "The zoo", { id: 5 }, {}, true );
-console.log( pictureLink ); // -> <a href="#!&type=pictures&id=5">The zoo</a>
+console.log( pictureLink ); //-> <a href="#!&type=pictures&id=5">The zoo</a>
 ```
 @codepen

--- a/doc/link.md
+++ b/doc/link.md
@@ -5,13 +5,13 @@
 
 @signature `route.link(innerText, data, props [, merge])`
 
-  Make an anchor tag (`<a>`) that when clicked on will update can-route's properties to match those in `data`. Creates and returns an anchor tag with an href of the route attributes passed into it, as well as any properties desired for the tag.
+  Make an anchor tag (`<a>`) that when clicked on will update can-route's properties to match those in `data`. Creates and returns an anchor tag with a href of the route attributes passed into it, as well as any properties desired for the tag.
 
   ```js
   import {route} from "can";
 
   const link = route.link( "My videos", { type: "videos" }, {}, false );
-  console.log( link ); //-> '<a href="#!&type=videos">My Videos</a>'
+  console.log( link ); //-> '<a href="#!&type=videos">My videos</a>'
   ```
   @codepen
 
@@ -30,7 +30,7 @@
      { className: "new" },
      false
    );
-   console.log( link ); //-> '<a href="#!&type=videos" class="new">My Videos</a>'
+   console.log( link ); //-> '<a href="#!&type=videos" class="new">My videos</a>'
    ```
    @codepen
 

--- a/doc/param.md
+++ b/doc/param.md
@@ -1,17 +1,22 @@
 @function can-route.param param
 @parent can-route.static
 
-@description Get a route path from given data.
+@description Creates a url fragment that represents provided state.
 
-@signature `route.param(data)`
+@signature `route.param( data )`
 
-  Parameterizes the raw JS object representation provided in data.
+  Parameterizes the raw JS object representation provided in data. Any remaining data is added at the end of the URL as &amp; separated key/value parameters.
 
   ```js
   import {route} from "can";
 
-  const result = route.param( { type: "video", id: 5 } );
-  console.log( result ); // -> "&type=video&id=5"
+  route.register( "{type}/{id}" );
+
+  const video = route.param( { type: "video", id: 5 } );
+  console.log( video ); // -> "video/5"
+
+  const notNewVideo = route.param( { type: "video", id: 5, isNew: false } );
+  console.log( notNewVideo ); // -> "video/5&isNew=false"
   ```
   @codepen
 
@@ -19,22 +24,3 @@
   @param {String} [currentRouteName] The current route name.  If provided, this can be used to "stick" the url to a previous route. By "stick", we mean that if there are multiple registered routes that match the `object`, the the `currentRouteName` will be used.
 
   @return {String} The route, with the data populated in it.
-
-@body
-
-If a route matching the provided data is found, that URL is built
-from the data. Any remaining data is added at the end of the
-URL as &amp; separated key/value parameters.
-
-```js
-import {route} from "can";
-
-route.register( "{type}/{id}" );
-
-const video = route.param( { type: "video", id: 5 } );
-console.log( video ); // -> "video/5"
-
-const notNewVideo = route.param( { type: "video", id: 5, isNew: false } );
-console.log( notNewVideo ); // -> "video/5&isNew=false"
-```
-@codepen

--- a/doc/param.md
+++ b/doc/param.md
@@ -21,6 +21,6 @@
   @codepen
 
   @param {data} object The data to populate the route with.
-  @param {String} [currentRouteName] The current route name.  If provided, this can be used to "stick" the url to a previous route. By "stick", we mean that if there are multiple registered routes that match the `object`, the the `currentRouteName` will be used.
+  @param {String} [currentRouteName] The current route name.  If provided, this can be used to "stick" the url to a previous route. By "stick", we mean that if there are multiple registered routes that match the `object`, the `currentRouteName` will be used.
 
   @return {String} The route, with the data populated in it.

--- a/doc/param.md
+++ b/doc/param.md
@@ -4,28 +4,37 @@
 @description Get a route path from given data.
 
 @signature `route.param(data)`
-@param {data} object The data to populate the route with.
-@param {String} [currentRouteName] The current route name.  If provided, this can be used to "stick" the url to a previous route. By "stick", we mean that if there are multiple registered routes that match the `object`, the the `currentRouteName` will be used.
 
-@return {String} The route, with the data populated in it.
+  Parameterizes the raw JS object representation provided in data.
+
+  ```js
+  import {route} from "can";
+
+  const result = route.param( { type: "video", id: 5 } );
+  console.log( result ); // -> "&type=video&id=5"
+  ```
+  @codepen
+
+  @param {data} object The data to populate the route with.
+  @param {String} [currentRouteName] The current route name.  If provided, this can be used to "stick" the url to a previous route. By "stick", we mean that if there are multiple registered routes that match the `object`, the the `currentRouteName` will be used.
+
+  @return {String} The route, with the data populated in it.
 
 @body
-
-Parameterizes the raw JS object representation provided in data.
-
-```js
-route.param({ type: "video", id: 5 });
-  // -> "type=video&id=5"
-```
 
 If a route matching the provided data is found, that URL is built
 from the data. Any remaining data is added at the end of the
 URL as &amp; separated key/value parameters.
 
 ```js
-route.register("{type}/{id}");
+import {route} from "can";
 
-route.param({ type: "video", id: 5 }) // -> "video/5"
-route.param({ type: "video", id: 5, isNew: false })
-  // -> "video/5&isNew=false"
+route.register( "{type}/{id}" );
+
+const video = route.param( { type: "video", id: 5 } );
+console.log( video ); // -> "video/5"
+
+const notNewVideo = route.param( { type: "video", id: 5, isNew: false } );
+console.log( notNewVideo ); // -> "video/5&isNew=false"
 ```
+@codepen

--- a/doc/register.md
+++ b/doc/register.md
@@ -24,7 +24,7 @@
   ```
   @codepen
 
-  @param {String} rule the fragment identifier to match.  The fragment identifier should contain characters (a-Z), optionally wrapped in braces `( { } )`. Identifiers wrapped in braces are interpreted as being properties on can-route’s map. Examples:
+  @param {String} rule the fragment identifier to match.  The fragment identifier should contain characters (a-Z), optionally wrapped in braces ( `{ }` ). Identifiers wrapped in braces are interpreted as being properties on can-route’s [can-route.data]. Examples:
 
    ```html
    <mock-url></mock-url>
@@ -42,6 +42,15 @@
    ```
    @codepen
 
-  @param {Object} [defaults] An object of default values. These defaults are applied to can-route’s map when the route is matched.
+  @param {Object} [defaults] An object of default values. These defaults are applied to can-route’s [can-route.data] when the route is matched.
 
-  @return {Object} The internal route object.  Use values on this object with caution. It is subject to change.
+  @return {Object} The internal route object. 
+    Since `route.register` returns the route object, register calls can me chained.
+
+    ```js
+    route.register("todos/{todoId}")
+      .register("users/{userId}");
+    ```
+
+
+

--- a/doc/register.md
+++ b/doc/register.md
@@ -24,7 +24,7 @@
   ```
   @codepen
 
-  @param {String} rule the fragment identifier to match.  The fragment identifier should contain characters (a-Z), optionally wrapped in braces ( `{ }` ). Identifiers wrapped in braces are interpreted as being properties on can-route’s [can-route.data]. Examples:
+  @param {String} rule the fragment identifier to match. The fragment identifier shouldn't contain characters that have special meaning: `/`, `{`, `}`, `?`, `#`, `!`, `=`, `[`, `]`, `&`), for example: `route.register("_||${foo}@^")` is a valid fragment. Identifiers wrapped in braces ( `{ }` ) are interpreted as being properties on can-route’s [can-route.data], these can contain (a-Z), typical property identifiers (`_`, `$`), and numbers after the first character. Examples:
 
    ```html
    <mock-url></mock-url>

--- a/doc/register.md
+++ b/doc/register.md
@@ -15,8 +15,7 @@
   import "//unpkg.com/mock-url@^5.0.0";
   import {route} from "can";
 
-  route.register( "{page}" );
-  route.data.page = "home";
+  route.register( "{page}", {page: "home"} );
   
   route.start();
   console.log( route.data.page ); // -> "home"
@@ -25,7 +24,7 @@
   ```
   @codepen
 
-  @param {String} rule the fragment identifier to match.  The fragment identifier should contain characters (a-Z), optionally wrapped in braces ( { } ). Identifiers wrapped in braces are interpreted as being properties on can-route’s map. Examples:
+  @param {String} rule the fragment identifier to match.  The fragment identifier should contain characters (a-Z), optionally wrapped in braces `( { } )`. Identifiers wrapped in braces are interpreted as being properties on can-route’s map. Examples:
 
    ```html
    <mock-url></mock-url>

--- a/doc/register.md
+++ b/doc/register.md
@@ -5,23 +5,44 @@
 
 @signature `route.register(rule [, defaults])`
 
-Create a url matching rule. Optionally provide defaults that will be applied to the underlying [can-route.data] when the rule matches.
+  Create a url matching rule. Optionally provide defaults that will be applied to the underlying [can-route.data] when the rule matches.
 
-The following sets `route.data.page = "cart"` when the url is `#cart` and
-`route.data.page = "home"` when the url is `#`.
+  The following sets `route.data.page = "cart"` when the url is `#cart` and `route.data.page = "home"` when the url is `#`.
 
-```js
-route.register( "{page}", { page: "home" } );
-```
+  ```html
+  <mock-url></mock-url>
+  <script type="module">
+  import "//unpkg.com/mock-url@^5.0.0";
+  import {route} from "can";
 
-@param {String} rule the fragment identifier to match.  The fragment identifier should contain characters (a-Z), optionally wrapped in braces ( { } ). Identifiers wrapped in braces are interpreted as being properties on can-route’s map. Examples:
+  route.register( "{page}" );
+  route.data.page = "home";
+  
+  route.start();
+  console.log( route.data.page ); // -> "home"
+  route.data.page = "cart";
+  </script>
+  ```
+  @codepen
 
-```js
-route.register( "{foo}" );
-route.register( "foo/{bar}" );
-```
+  @param {String} rule the fragment identifier to match.  The fragment identifier should contain characters (a-Z), optionally wrapped in braces ( { } ). Identifiers wrapped in braces are interpreted as being properties on can-route’s map. Examples:
 
-@param {Object} [defaults] An object of default values. These defaults are applied to can-route’s map when the route is matched.
+   ```html
+   <mock-url></mock-url>
+   <script type="module">
+   import "//unpkg.com/mock-url@^5.0.0";
+   import {route} from "can";
+  
+   route.register( "{foo}" );
+   route.register( "foo/{bar}" );
+   console.log( route.data ); //-> {foo: undefined, bar: undefined}
+   
+   route.start();
+   route.data.bar = "fie"; // Url hash changes to #!foo/fie
+   </script>
+   ```
+   @codepen
 
-@return {Object} The internal route object.  Use values on this object with caution. It is
- subject to change.
+  @param {Object} [defaults] An object of default values. These defaults are applied to can-route’s map when the route is matched.
+
+  @return {Object} The internal route object.  Use values on this object with caution. It is subject to change.

--- a/doc/rule.md
+++ b/doc/rule.md
@@ -1,21 +1,20 @@
 @function can-route.rule rule
 @parent can-route.static
-@description Get the routing rule that matches a url.
 
+@description Get the routing rule that matches a url.
 
 @signature `route.rule(url)`
 
-```js
-route.register( "recipes/{recipeId}" );
-route.register( "tasks/{taskId}" );
-route.rule( "recipes/5" ); //-> "recipes/{recipeId}"
-```
+  ```js
+  import {route} from "can";
+  
+  route.register( "recipes/{recipeId}" );
+  route.register( "tasks/{taskId}" );
+  console.log( route.rule( "recipes/5" ) ); //-> "recipes/{recipeId}"
+  ```
+  @codepen
 
-@param {String} url A url or url fragment.
+  @param {String} url A url or url fragment.
 
-@return {String|undefined} Returns the [can-route.register registered] routing rule
-that best matches the provided url.  If no rule matches, `undefined` is returned.
-
-
-
-@body
+  @return {String|undefined} Returns the [can-route.register registered] routing rule
+  that best matches the provided url.  If no rule matches, `undefined` is returned.

--- a/doc/rule.md
+++ b/doc/rule.md
@@ -3,7 +3,9 @@
 
 @description Get the routing rule that matches a url.
 
-@signature `route.rule(url)`
+@signature `route.rule( url )`
+
+  Returns a string that best matches the provided url.
 
   ```js
   import {route} from "can";

--- a/doc/rule.md
+++ b/doc/rule.md
@@ -20,3 +20,9 @@
 
   @return {String|undefined} Returns the [can-route.register registered] routing rule
   that best matches the provided url.  If no rule matches, `undefined` is returned.
+
+@body
+
+## Use
+
+`route.rule` is used internally by [can-stache-route-helpers].

--- a/doc/rule.md
+++ b/doc/rule.md
@@ -16,7 +16,7 @@
   ```
   @codepen
 
-  @param {String} url A url or url fragment.
+  @param {String} url A url fragment.
 
   @return {String|undefined} Returns the [can-route.register registered] routing rule
   that best matches the provided url.  If no rule matches, `undefined` is returned.

--- a/doc/rule.md
+++ b/doc/rule.md
@@ -21,8 +21,3 @@
   @return {String|undefined} Returns the [can-route.register registered] routing rule
   that best matches the provided url.  If no rule matches, `undefined` is returned.
 
-@body
-
-## Use
-
-`route.rule` is used internally by [can-stache-route-helpers].

--- a/doc/start.md
+++ b/doc/start.md
@@ -6,8 +6,7 @@
 
 @signature `route.start()`
 
-  Sets up the two-way binding between the hash and the can-route observable
-  map and sets the route map to its initial values.
+  Sets up the two-way binding between the hash and the can-route observable map and sets the route map to its initial values.
 
   ```html
   <mock-url></mock-url>

--- a/doc/start.md
+++ b/doc/start.md
@@ -2,20 +2,28 @@
 @parent can-route.static
 @release 3.3
 
-Initializes can-route.
+@description Initializes can-route.
 
 @signature `route.start()`
 
-Sets up the two-way binding between the hash and the can-route observable
-map and sets the route map to its initial values.
+  Sets up the two-way binding between the hash and the can-route observable
+  map and sets the route map to its initial values.
 
-```js
-route.register( "{page}", { page: "home" } );
-route.start();
-route.data.page; // -> "home"
-```
+  ```html
+  <mock-url></mock-url>
+  <script type="module">
+  import "//unpkg.com/mock-url@^5.0.0";
+  import {route} from "can";
 
-@return {can-route} The can-route object.
+  route.register( "{page}", { page: "home" } );
+  route.start();
+  console.log( route.data.page ); // -> "home"
+  </script>
+  ```
+  @codepen
+  @highlight 7
+
+  @return {can-route} The can-route object.
 
 @body
 
@@ -24,7 +32,17 @@ route.data.page; // -> "home"
 After setting all your routes, call `route.start()`.
 
 ```js
+import {route} from "can";
+
 route.register( "overview/{dateStart}-{dateEnd}" );
 route.register( "{type}/{id}" );
 route.start();
+
+console.log( route.data ); // -> {
+//   dateEnd: undefined,
+//   dateStart: undefined,
+//   id: undefined,
+//   type: undefined
+// }
 ```
+@codepen

--- a/doc/start.md
+++ b/doc/start.md
@@ -6,7 +6,7 @@
 
 @signature `route.start()`
 
-  Sets up the two-way binding between the hash and the [can-route.data can-route.data] and sets the route.data to its initial values.
+  Sets up the two-way binding between the hash and the [can-route.data can-route.data] and sets the route.data to its initial values. If URL data and route.data set at the same time the URL data will take precedence.
 
   ```html
   <mock-url></mock-url>

--- a/doc/start.md
+++ b/doc/start.md
@@ -2,11 +2,11 @@
 @parent can-route.static
 @release 3.3
 
-@description Initializes can-route.
+@description Initializes the two way relationship between the url and route.data.
 
 @signature `route.start()`
 
-  Sets up the two-way binding between the hash and the can-route observable map and sets the route map to its initial values.
+  Sets up the two-way binding between the hash and the [can-route.data can-route.data] and sets the route.data to its initial values.
 
   ```html
   <mock-url></mock-url>

--- a/doc/stop.md
+++ b/doc/stop.md
@@ -38,23 +38,55 @@
 If you need to disconnect an observable from the URL, call stop.
 To reconnect, call [can-route.start] again.
 
+In the example shows a possible use reason for stopping can-route. 
+When the user logs out the page doesn't change, though the hash still updates.
+Notice the `logout`/`login` functions start and stop route. When logged out you can't change the page,
+even though the hash still updates.
+
 ```html
 <mock-url></mock-url>
+<my-app></my-app>
 <script type="module">
-import "//unpkg.com/mock-url@^5.0.0";
-import {route} from "can";
+import {DefineMap, route, Component } from "can";
+import "//unpkg.com/mock-url@^5";
 
-route.register("{page}", { page: "" });
-route.start();
-
-route.stop();
-route.data.page = "home"; // doesn't goto home
-
-setTimeout(() => {
-  route.start();
-  route.data.page = "cart"; // hash routes to cart.
-}, 3000);
-
+Component.extend({
+  tag: "my-app",
+  view: `<a href="{{ routeUrl(page="dashboard") }}">dashboard</a>
+    <a href="{{ routeUrl(page="admin") }}">admin</a><br />
+    {{# if (showLogin) }}
+      <button on:click="login()">login</button>
+    {{ else }}
+      <button on:click="logout()">logout</button>
+    {{/ if }}
+    <h1>{{componentToShow}}</h1>
+    `,
+  ViewModel: {
+    routeData: {
+      default() {
+        route.data = new DefineMap();
+        route.register("{page}");
+        route.data.page = "admin";
+        route.start();
+        return route.data;
+      }
+    },
+    logout() {
+      route.data.page = "login";
+      route.stop();
+    },
+    login() {
+      route.start();
+      route.data.page = "admin";
+    },
+    get componentToShow() {
+      return this.routeData.page;
+    },
+    get showLogin() {
+      return this.routeData.page === "login";
+    } 
+  }
+});
 </script>
 ```
 @codepen

--- a/doc/stop.md
+++ b/doc/stop.md
@@ -46,6 +46,7 @@ import {route} from "can";
 
 route.register("{page}", { page: "" });
 route.start();
+
 route.stop();
 route.data.page = "home"; // doesn't goto home
 

--- a/doc/stop.md
+++ b/doc/stop.md
@@ -64,7 +64,6 @@ Component.extend({
   ViewModel: {
     routeData: {
       default() {
-        route.data = new DefineMap();
         route.register("{page}");
         route.data.page = "admin";
         route.start();

--- a/doc/stop.md
+++ b/doc/stop.md
@@ -2,30 +2,58 @@
 @parent can-route.static
 @release 4.1
 
-Stops listening to the [can-route.data] observable and tears down any setup bindings.
+@description Stops listening to the [can-route.data] observable and tears down any setup bindings.
 
 @signature `route.stop()`
 
-Stops listening to changes in the URL as well as the observable defined in [can-route.data], and removes the current binding.
+  Stops listening to changes in the URL as well as the observable defined in [can-route.data], and removes the current binding.
 
-```js
-route.register( "{page}", { page: "home" } );
-route.start();
-route.data.page = "home";
-route.stop();
-route.data.page = "cart"; // hash is still #home
-```
+  ```html
+  <mock-url></mock-url>
+  <script type="module">
+  import "//unpkg.com/mock-url@^5.0.0";
+  import {route} from "can";
 
-@return {can-route} The can-route object.
+  route.register("{page}", { page: "" });
+  route.start();
+  route.data.page = "home";
+
+  // Changing the route is not synchronous
+  setTimeout(() => {
+    route.stop();
+    route.data.page = "cart"; // hash is still "home"
+    console.log( location.hash ) //-> "#!home"
+  }, 1000);
+
+  </script>
+  ```
+  @codepen
+
+  @return {can-route} The can-route object.
 
 @body
 
 ## Use
 
-If you need to disconnect an observable from the URL, call stop:
-
-```js
-route.stop();
-```
-
+If you need to disconnect an observable from the URL, call stop.
 To reconnect, call [can-route.start] again.
+
+```html
+<mock-url></mock-url>
+<script type="module">
+import "//unpkg.com/mock-url@^5.0.0";
+import {route} from "can";
+
+route.register("{page}", { page: "" });
+route.start();
+route.stop();
+route.data.page = "home"; // doesn't goto home
+
+setTimeout(() => {
+  route.start();
+  route.data.page = "cart"; // hash routes to cart.
+}, 3000);
+
+</script>
+```
+@codepen

--- a/doc/url.md
+++ b/doc/url.md
@@ -25,6 +25,7 @@ Similar to [can-route.link], but instead of creating an anchor tag, `route.url` 
 
 ```js
 import {route} from "can";
+
 const url = route.url( { type: "videos", id: 5 } );
 console.log( url ); //-> "#!&type=videos&id=5"
 ```

--- a/doc/url.md
+++ b/doc/url.md
@@ -16,14 +16,27 @@
   @codepen
 
   @param {Object} data The data to populate the route with.
-  @param {Boolean} [merge] Whether the given options should be merged into the current state of the route.
+  @param {Boolean} merge Whether the given options should be merged into the current state of the route.
+   ```js
+   import {route} from "can";
+
+   route.data.update( {type: "items", id: 5} );
+   route.start();
+ 
+   setTimeout(() => {
+     const url = route.url( { page: "home" }, true );
+     console.log( url ); //-> ""#!&type=test&id=5&page=home""
+   }, 100);
+   ```
+   @codepen
+
   @return {String} The route URL and query string.
 
 @body
 
 ## Use
 
-Similar to [can-route.link], but instead of creating an anchor tag, `route.url` creates only the URL based on the route options passed into it.
+`route.url` creates only the URL based on the route options passed into it.
 
 ```js
 import {route} from "can";

--- a/doc/url.md
+++ b/doc/url.md
@@ -5,36 +5,42 @@
 
 @signature `route.url(data [, merge])`
 
-Make a URL fragment that when set to window.location.hash will update can-route's properties
-to match those in `data`.
+  Make a URL fragment that when set to window.location.hash will update can-route's properties to match those in `data`.
 
-```js
-route.url({ page: "home" });
-// -> "#!page=home"
-```
+  ```js
+  import {route} from "can";
 
-@param {Object} data The data to populate the route with.
-@param {Boolean} [merge] Whether the given options should be merged into
-the current state of the route.
-@return {String} The route URL and query string.
+  const url = route.url( { page: "home" } );
+  console.log( url ); //-> "#!&page=home"
+  ```
+  @codepen
+
+  @param {Object} data The data to populate the route with.
+  @param {Boolean} [merge] Whether the given options should be merged into the current state of the route.
+  @return {String} The route URL and query string.
 
 @body
-Similar to [can-route.link], but instead of creating an anchor tag,
-`route.url` creates only the URL based on the route options passed into it.
+
+Similar to [can-route.link], but instead of creating an anchor tag, `route.url` creates only the URL based on the route options passed into it.
 
 ```js
-route.url( { type: "videos", id: 5 } );
-  // -> "#!type=videos&id=5"
+import {route} from "can";
+const url = route.url( { type: "videos", id: 5 } );
+console.log( url ); //-> "#!&type=videos&id=5"
 ```
+@codepen
 
-If a route matching the provided data is found the URL is built from the
-data. Any remaining data is added at the end of the URL as & separated
-key/value parameters.
+If a route matching the provided data is found the URL is built from the data. Any remaining data is added at the end of the URL as & separated key/value parameters.
 
 ```js
+import {route} from "can";
+
 route.register("{type}/{id}");
 
-route.url( { type: "videos", id: 5 } ) // -> "#!videos/5"
-route.url( { type: "video", id: 5, isNew: false } )
-  // -> "#!video/5&isNew=false"
+const video = route.url( { type: "videos", id: 5 } );
+console.log( video ); //-> "#!videos/5"
+
+const notNewVideo = route.url( { type: "video", id: 5, isNew: false } );
+console.log( notNewVideo ); //-> "#!video/5&isNew=false"
 ```
+@codepen

--- a/doc/url.md
+++ b/doc/url.md
@@ -21,6 +21,8 @@
 
 @body
 
+## Use
+
 Similar to [can-route.link], but instead of creating an anchor tag, `route.url` creates only the URL based on the route options passed into it.
 
 ```js

--- a/doc/urlData.md
+++ b/doc/urlData.md
@@ -4,19 +4,18 @@
 Specifies an observable value that represents the URL. Useful for changing
 what URL [can-route route] is cross-bound to.
 
-@type {ValueObservable} `urlData` is an observable value that represents the part of the URL cross
-  bound to the [can-route.data] state object.  It can be set to other observable urls like [can-route-pushstate]
-  or [can-route-mock]. It defaults to [can-route-hash].
+@type {ValueObservable} `urlData` is an observable value that represents the part of the URL cross bound to the [can-route.data] state object.  It can be set to other observable urls like [can-route-pushstate] or [can-route-mock]. It defaults to [can-route-hash].
 
   The following shows setting `urlData` to another observable.
 
   ```js
-  import {route, RouteMock, DefineMap} from "can";
+  import {route, DefineMap} from "can";
+  import {RouteMock} from "//unpkg.com/can@5/everything.mjs";
 
   // route.data will update routeMock and be updated by changes in
   // routeMock.
-  var routeMock = route.urlData = new RouteMock();
-  var routeData = route.data = new DefineMap({},false);
+  const routeMock = route.urlData = new RouteMock();
+  const routeData = route.data = new DefineMap({},false);
 
   // begin binding
   route.start()
@@ -24,7 +23,7 @@ what URL [can-route route] is cross-bound to.
   // simulate setting the URL
   routeMock.value = "foo=bar";
 
-  routeData.foo //-> "bar";
+  console.log( routeData.foo ); //-> "bar";
   ```
   @codepen
 
@@ -35,7 +34,6 @@ what URL [can-route route] is cross-bound to.
 > WARNING: The following is non-normative and may change in a
 > future release.  Please let us know if you are trying to create your own
 > observable and we will work with you to stabilize the API.
-
 
 Besides implementing the standard `ValueObservable` symbols:
 

--- a/doc/urlData.md
+++ b/doc/urlData.md
@@ -9,13 +9,12 @@ what URL [can-route route] is cross-bound to.
   The following shows setting `urlData` to another observable.
 
   ```js
-  import {route, DefineMap} from "can";
-  import {RouteMock} from "//unpkg.com/can@5/everything.mjs";
+  import {route, RouteMock} from "can/everything";
 
   // route.data will update routeMock and be updated by changes in
   // routeMock.
   const routeMock = route.urlData = new RouteMock();
-  const routeData = route.data = new DefineMap({},false);
+  const routeData = route.data;
 
   // begin binding
   route.start()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-route",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Observable front-end application routing for CanJS.",
   "homepage": "https://canjs.com/doc/can-route.html",
   "license": "MIT",

--- a/src/binding-proxy.js
+++ b/src/binding-proxy.js
@@ -5,6 +5,7 @@ var SimpleObservable = require("can-simple-observable");
 
 var urlDataObservable = new SimpleObservable(null);
 
+canReflect.setName(urlDataObservable,"route.urlData");
 var bindingProxy = {
     defaultBinding: null,
     urlDataObservable: urlDataObservable,

--- a/test/route-define-test.js
+++ b/test/route-define-test.js
@@ -7,7 +7,8 @@ var DefineMap = require('can-define/map/map');
 var canReflect = require('can-reflect');
 var stacheKey = require("can-stache-key");
 var Observation = require("can-observation");
-
+var queues = require("can-queues");
+window.queues = queues;
 var mockRoute = require("./mock-route-binding");
 
 require('can-observation');
@@ -100,18 +101,20 @@ if (typeof steal !== 'undefined') {
 
 
 		canRoute.start();
-		var isOnTestPage = new Observation(function(){
+		var isOnTestPage = new Observation(function isCurrent(){
 			return canRoute.isCurrent({page: "test"});
 		});
 
-		canReflect.onValue(isOnTestPage, function(){
+		canReflect.onValue(isOnTestPage, function isCurrentChanged(){
+			// unbind now because isCurrent depends on urlData
+			isOnTestPage.off();
 			mockRoute.stop();
 			QUnit.start();
 		});
 
 		equal(canRoute.isCurrent({page: "test"}), false, "initially not on test page")
 		setTimeout(function(){
-			canRoute.attr("page","test");
+			canRoute.data.set("page","test");
 		},20);
 	});
 


### PR DESCRIPTION
Fixes most of the issues #209

## [can-route.html](https://www.canjs.com/doc/can-route.html)
- [x] misspelling _aswell_ -> _as well_
- [x] update examples:
  - [x] imports from _can_
- [x] remove references of hooking up `route.data` to HTMLElements.
- [x] indentation

## [can-route.start.html](https://www.canjs.com/doc/can-route.start.html)
- [x] codepen
- [x] add description
- [x] indentation

## [can-route.stop.html](https://www.canjs.com/doc/can-route.stop.html)
- [x] codepen
  - [x] using [`mock-url`](unpkg.com/mock-url@^5.0.0)
- [x] add description
- [x] indentation

## [can-route.currentRule.html](https://www.canjs.com/doc/can-route.currentRule.html)
- [x] codepen
  - [x] move example from body to signature.
- [x] indentation

## [can-route.deparam.html](https://www.canjs.com/doc/can-route.deparam.html)
- [x] codepen
  - [x] using [`mock-url`](unpkg.com/mock-url@^5.0.0)
- [x] indentation
- [x] updated

## [can-route.isCurrent](https://www.canjs.com/doc/can-route.isCurrent.html)
- [x] codepen
- [x] added `@description`.
- [x] indentation
- [x] spelling `agains` -> `against`

## [can-route.link.html](https://www.canjs.com/doc/can-route.link.html)
- [x] codepen
  - [x] moved example from body to signature
  - [x] moved relevant example from body to props param.
  - [x] updated example comments to include leading ampersand `&`.
- [x] indentation

## [can-route.param.html](https://www.canjs.com/doc/can-route.param.html)
- [x] codepen
  - [x] moved example from body to signature
- [x] indentation

## [can-route.url.html](https://www.canjs.com/doc/can-route.url.html)
- [x] codepen
- [x] indentation

## [can-route.data.html](https://www.canjs.com/doc/can-route.data.html)
- [x] deprecate setting to HTMLelement
  - [x] linked to routing guide.
- [x] removed complete example heading in favor of routing guide.