### PR TITLE
Include routeData reflections in prod

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -96,6 +96,7 @@ var RouteRegistry = {
 	    		}
 	    	});
     	}
+			//!steal-remove-end
 
 			// Assign to the instance props
 			if(this.data instanceof RouteData) {
@@ -115,7 +116,6 @@ var RouteRegistry = {
 				});
 			}
 
-    	//!steal-remove-end
     	// Add route in a form that can be easily figured out.
     	return RouteRegistry.routes[url] = {
     		// A regular expression that will match the route when variable values


### PR DESCRIPTION
There was a steal-remove-end in the wrong spot, which caused the code
that defines keys for the RouteData DefineMap to not be included in
prod. Fixes #213