### PR TITLE
Fix the deprecated group’s name in the docs

### DIFF
--- a/doc/can-route.md
+++ b/doc/can-route.md
@@ -1,6 +1,6 @@
 @module {Object} can-route can-route
 @group can-route.static 0 static
-@group deprecated 1 deprecated
+@group can-route.deprecated 1 deprecated
 @download can/route
 @test can-route/test.html
 @parent can-routing


### PR DESCRIPTION
Just “deprecated” was causing can-util’s deprecated methods to show in can-route’s docs.