### PR TITLE
Add a warning when .data is set after .register() is called in can-route

### DIFF
--- a/can-route.js
+++ b/can-route.js
@@ -1,5 +1,5 @@
 // # can-route.js
-// Manage browser history and client state by synchronizing 
+// Manage browser history and client state by synchronizing
 // the window.location.hash with an observable.
 
 "use strict";
@@ -26,7 +26,7 @@ var isWebWorker =  require("can-globals/is-web-worker/is-web-worker");
 var isBrowserWindow =  require("can-globals/is-browser-window/is-browser-window");
 
 // ## hashchangeObservable
-// `hashchangeObservable` is an instance of `Hashchange`, instances of 
+// `hashchangeObservable` is an instance of `Hashchange`, instances of
 // `Hashchange` are two-way bound to `window.location.hash` once the
 // instances have a listener.
 var hashchangeObservable = new Hashchange();
@@ -346,6 +346,13 @@ Object.defineProperty(canRoute, "data", {
 		}
 	},
 	set: function(data) {
+		//!steal-remove-start
+		if (typeof process !== "undefined" && process.env.NODE_ENV !== "production") {
+			if (Object.keys(registerRoute.routes).length > 0) {
+				devLog.warn("can-route: Setting can-route.data after calling can-route.register() may result in unexpected behavior. Set can-route.data before calling can-route.register().");
+			}
+		}
+		//!steal-remove-end
 		if ( canReflect.isConstructorLike(data) ) {
 			data = new data();
 		}

--- a/test/route-data-test.js
+++ b/test/route-data-test.js
@@ -4,6 +4,8 @@ var SimpleMap = require("can-simple-map");
 var canReflect = require("can-reflect");
 var canSymbol = require("can-symbol");
 var mockRoute = require("./mock-route-binding");
+var RouteData = require("../src/routedata");
+var testHelpers = require("can-test-helpers");
 
 require("can-observation");
 
@@ -101,4 +103,13 @@ QUnit.test("Default map registers defaults as properties", function(assert) {
 
 		mockRoute.hash.value = "#!";
     canRoute.start();
+});
+
+testHelpers.dev.devOnlyTest("should warn when .data is set after .register() is called", function (assert) {
+	var teardown = testHelpers.dev.willWarn(/Set can-route.data before/);
+
+	canRoute.register("{page}/{subpage}");
+	canRoute.data = new RouteData();
+
+	assert.equal(teardown(), 1);
 });


### PR DESCRIPTION
`.register()` will read `.data` when it’s called, so setting `.data` later may have unintended consequences.

Suggestions welcome on the warning’s wording and if we should add more docs around this.