### PR TITLE
fix: remove trailing slash to allow deparam with urls that end with a slash

### DIFF
--- a/src/deparam.js
+++ b/src/deparam.js
@@ -26,11 +26,6 @@ function toURLFragment(url) {
 	if (root.lastIndexOf("/") === root.length - 1 && url.indexOf("/") === 0) {
 		url = url.substr(1);
 	}
-
-	// Remove any trialing `/` to allow for pushstate to be deparamed properly
-	if (url.lastIndexOf("/") === url.length - 1) {
-		url = url.slice(0, -1);
-	}
 	
 	return url;
 }
@@ -55,7 +50,11 @@ function canRoute_getRule(url) {
 }
 
 function canRoute_deparam(url) {
-
+	// Remove any trialing `/` to allow for pushstate to be deparamed properly
+	if (url.length > 1 && url.lastIndexOf("/") === url.length - 1) {
+		url = url.slice(0, -1);
+	}
+	
 	var route = canRoute_getRule(url),
 		querySeparator = bindingProxy.call("querySeparator"),
 		paramsMatcher = bindingProxy.call("paramsMatcher");

--- a/src/deparam.js
+++ b/src/deparam.js
@@ -26,6 +26,12 @@ function toURLFragment(url) {
 	if (root.lastIndexOf("/") === root.length - 1 && url.indexOf("/") === 0) {
 		url = url.substr(1);
 	}
+
+	// Remove any trialing `/` to allow for pushstate to be deparamed properly
+	if (url.lastIndexOf("/") === url.length - 1) {
+		url = url.slice(0, -1);
+	}
+	
 	return url;
 }
 

--- a/test/param-deparam-test.js
+++ b/test/param-deparam-test.js
@@ -326,6 +326,17 @@ QUnit.test("param / deparam / rule", function(assert) {
 					input: { page: "foo", section: "bar" },
 					output: "foo/bar"
 				},
+				{
+					method: "deparam",
+					input: "foo/bar",
+					output: { page: "foo", section: "bar" }
+				},
+				// handles trailing slash (`/`) in url
+				{
+					method: "deparam",
+					input: "foo/bar/",
+					output: { page: "foo", section: "bar" }
+				},
 				// handles falsey values
 				// handles ""
 				{
@@ -336,7 +347,7 @@ QUnit.test("param / deparam / rule", function(assert) {
 				{
 					method: "deparam",
 					input: "home/",
-					output: {}
+					output: { page: "home" }
 				},
 				{
 					method: "rule",


### PR DESCRIPTION
### Description

I'm working with a team to perform static site generation that works with `can-route`, and currently, `can-route`'s `canRoute_deparam` method doesn't handle urls that end with a trailing slash (`/`) properly. This has become problematic when trying to use `express` to act as a local static server during development.

This PR updates `canRoute_deparam` to removing trailing slash (`/`) from url when trying to `deparam` for path variables.

### Recreate Steps

```javascript
import route from "can-route"
import "can-stache-route-helpers"

route.urlData = new RoutePushstate()

route.register("{page}", { page: "home" })
route.register("tasks/{taskId}", { page: "tasks" })
route.register("progressive-loading/{loadId}", { page: "progressive-loading" })

route.start()
```

This allows for urls like: "progressive-loading/moo" which `deparam`s to:

```json
{
  "page": "progressive-loading",
  "loadId": "moo"
}
```

When the url is: "progressive-loading/moo/" (has trailing slash `/`), `deparam`s to empty object:

```json
{}
```

When removing the trailing slash (`/`) then attempting to `deparam` works as expected.

### Reason to support urls with trailing slash (`/`)

When serving static pages using `express`, following their [basic static server example](https://expressjs.com/en/starter/static-files.html) looks something like this:

```javascript
const express = require("express")
const app = express()

app.use(express.static('static_files'))// return all static files from "static_files"
app.use("*", express.static('static_files/404'))// if there's no match, return 404 page

app.listen(8080, function () {
  console.log("Example app listening on port 8080")
})
```

"/static_files/":
```
/static_files/index.html
/static_files/tasks/index.html
/static_files/progressive-loading/root/index.html
/static_files/progressive-loading/moo/index.html
/static_files/progressive-loading/cow/index.html
/static_files/404/index.html
```